### PR TITLE
PySide6版UIの追加と起動手順の更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 desktop_gui_settings.yaml
 export_prompts_to_csv.py
 window_position_app_image_prompt_creator.txt
-\__pycache__
+__pycache__/
+*.pyc
+.DS_Store
+.env
+.venv/
+venv/
+.mypy_cache/
+.pytest_cache/
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Midjourney 向けの画像生成プロンプトを、SQLite の属性データ�
 
 ## 前提／セットアップ
 - **Python**: 3.10+ 推奨
-- **依存ライブラリ**: `requests`, `PyYAML`
+- **依存ライブラリ**: `requests`, `PyYAML`, `PySide6`
 ```bash
-pip install requests PyYAML
+pip install requests PyYAML PySide6
 ```
 - **設定ファイル**: `app_image_prompt_creator/desktop_gui_settings.yaml`
   - 例は `app_image_prompt_creator/desktop_gui_settings.yaml.example`
@@ -57,11 +57,16 @@ setx OPENAI_API_KEY "sk-xxxxx"
   ```
 
 ## 起動方法
-```bash
-python app_image_prompt_creator/app_image_prompt_creator_2.py
-```
+- Tkinter 版（従来UI）
+  ```bash
+  python app_image_prompt_creator/app_image_prompt_creator_2.py
+  ```
+- PySide6 版（新UI・非同期LLM対応）
+  ```bash
+  python app_image_prompt_creator/app_image_prompt_creator_qt.py
+  ```
 
-起動後、右側にメイン設定、左側に出力欄とサブ操作が表示されます。初回は DB の前提テーブル（後述）が用意されている必要があります。
+起動後、右側にメイン設定、左側に出力欄とサブ操作が表示されます。初回は DB の前提テーブル（後述）が用意されている必要があります。PySide6 版はQMainWindowベースの2ペイン構成で、CSV投入やLLM呼び出しをQtダイアログ/スレッドで行います。
 
 ## 使い方（基本）
 1. **属性を選ぶ**


### PR DESCRIPTION
## 概要
- PySide6ベースのQMainWindow版UIを新規追加し、属性選択・末尾プリセット・オプション・CSV入出力・動画用整形・クリップボード操作をQtウィジェットで再構成しました
- LLM呼び出しをQThreadベースのワーカーで非同期化し、エラー/完了時にQtダイアログで通知するようにしました
- PySide6依存と新規エントリーポイントをREADMEに追記し、不要ファイルを.gitignoreで除外しました

## 動作確認
- python -m compileall app_image_prompt_creator_qt.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4b04c4c0832ca4bc8f32d4e1c5e8)