### PR TITLE
CSV投入処理のバリデーション強化と失敗行エクスポート対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 venv/
 .mypy_cache/
 .pytest_cache/
+failed_csv_rows_*.csv
 *.sqlite3
 *.sqlite3-journal
 *.db

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ setx OPENAI_API_KEY "sk-xxxxx"
     "A serene zen garden with stone lantern.","12,34,56"
     ```
   - 貼付け内容から `prompts` と `prompt_attribute_details` に登録します
+  - 列数が2列でない場合や `attribute_detail_id` が数値でない場合は投入せず、原因と該当行を `failed_csv_rows_YYYYMMDD_HHMMSS.csv` に書き出して再投入の手がかりを提示します
 - **エクスポート**: 「(DB確認用CSV出力)」で現在のDB内容を確認用CSVに出力
 
 補足:


### PR DESCRIPTION
## 概要
- CSVインポートを `csv.reader` でパースし、列数と数値IDを検証する安全策を追加
- SQLiteを `with conn:` でトランザクション管理し、例外時にロールバックされるよう変更
- パース失敗行の警告表示とCSVエクスポートを実装し、READMEとgitignoreを更新

## テスト
- python -m compileall app_image_prompt_creator_qt.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5d858ebc832c9c0b853734e7317f)