### PR TITLE
属性選択をID基準に変更して重複説明の回帰テストを追加

### DIFF
--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -1,0 +1,101 @@
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+PySide6 = pytest.importorskip("PySide6")
+from PySide6 import QtWidgets
+
+import app_image_prompt_creator_qt as qt_app
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qt_application():
+    """オフスクリーン描画で Qt アプリを初期化し、GUI依存テストを安定化させる。"""
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def _prepare_test_db(db_path: Path) -> None:
+    """重複説明を含む属性データセットを作成する。"""
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.executescript(
+        """
+        CREATE TABLE attribute_types (
+            id INTEGER PRIMARY KEY,
+            attribute_name TEXT,
+            description TEXT
+        );
+        CREATE TABLE attribute_details (
+            id INTEGER PRIMARY KEY,
+            attribute_type_id INTEGER,
+            description TEXT,
+            value TEXT
+        );
+        CREATE TABLE prompts (
+            id INTEGER PRIMARY KEY,
+            content TEXT
+        );
+        CREATE TABLE prompt_attribute_details (
+            prompt_id INTEGER,
+            attribute_detail_id INTEGER
+        );
+        """
+    )
+    cursor.execute(
+        "INSERT INTO attribute_types (id, attribute_name, description) VALUES (?, ?, ?)",
+        (1, "style", "画風"),
+    )
+    cursor.executemany(
+        "INSERT INTO attribute_details (id, attribute_type_id, description, value) VALUES (?, ?, ?, ?)",
+        [
+            (1, 1, "印象派", "impressionist"),
+            (2, 1, "印象派", "neo_impressionist"),
+        ],
+    )
+    cursor.execute("INSERT INTO prompts (id, content) VALUES (?, ?)", (1, "First prompt"))
+    cursor.execute("INSERT INTO prompts (id, content) VALUES (?, ?)", (2, "Second prompt"))
+    cursor.executemany(
+        "INSERT INTO prompt_attribute_details (prompt_id, attribute_detail_id) VALUES (?, ?)",
+        [
+            (1, 1),
+            (2, 2),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def prompt_generator(tmp_path, monkeypatch, qt_application):
+    """テスト用DBを差し替えたウィンドウインスタンスを返す。"""
+
+    db_path = tmp_path / "test.db"
+    _prepare_test_db(db_path)
+    monkeypatch.setattr(qt_app, "DEFAULT_DB_PATH", str(db_path))
+    window = qt_app.PromptGeneratorWindow()
+    window.spin_row_num.setValue(1)
+    yield window
+    window.close()
+
+
+def test_generate_text_uses_selected_attribute_id(prompt_generator):
+    """同じ説明文の属性から、IDで指定したほうのみ抽出されることを確認する。"""
+
+    detail_combo = prompt_generator.attribute_combo_map[1]
+    second_detail_index = detail_combo.findData(2)
+    assert second_detail_index >= 0
+    detail_combo.setCurrentIndex(second_detail_index)
+    prompt_generator.attribute_count_map[1].setCurrentText("1")
+
+    prompt_generator.generate_text()
+
+    assert "Second prompt." in prompt_generator.main_prompt
+    assert "First prompt" not in prompt_generator.main_prompt


### PR DESCRIPTION
## 概要
- 属性選択コンボボックスに attribute_detail.id を保持し、IDベースでプロンプト抽出を行うように修正
- Tk版も同様にIDで内部参照するようロジックを整理し、重複説明時の取り違えを防止
- 重複した説明文を含むデータセットで想定した属性のみを抽出するPySide6向け回帰テストを追加

## テスト
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6a0b4d24832c9adebfdb3e49ad4f)