### PR TITLE
movie向けUIを整理し、動画プリセットと演出制約を拡張

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@
 
 ### 動画生成向け
 - **末尾プリセット（movie）**: `{"video_style": ...}` JSON で動画スタイルを指定
+- **添付画像世界プリセット**: 添付画像に写る世界をそのまま動画として展開する `movie` 末尾1を選択可能
 - **content_flags**: ナレーション・BGM・字幕・カット数などをJSONで付与
 - **用途別UI切替**: 末尾プリセット用途を `movie` にすると Midjourney 用「オプション」を非表示化
+- **演出制約の品質指定**: `完全実写映像` と `8K超高精細映像` を個別にON/OFF可能
 - **JSON整形**: メインテキストを `world_description` や `storyboard` に変換
 - **LLM改良**: 世界観整形 / カオスミックス
 
@@ -108,7 +110,7 @@ python app_image_prompt_creator/app_image_prompt_creator_qt.py
 高解像度写真、8K、イラスト系の文末テキストを収録しています。
 
 ### movie プリセット
-JSON形式で `video_style` を定義します。プリセットによっては `content_flags_defaults` と `direction_constraints_defaults` も同時に持ち、選択した瞬間に動画向けの既定パラメータを UI へ流し込めます。TV番組系（ニュース、旅番組、ドキュメンタリー等）、映画系（歴史超大作、青春映画、ファンタジー等）、報道・現地リポート、ロケ・体験番組など多数のカテゴリから選択できます。
+JSON形式で `video_style` を定義します。プリセットによっては `content_flags_defaults` と `direction_constraints_defaults` も同時に持ち、選択した瞬間に動画向けの既定パラメータを UI へ流し込めます。TV番組系（ニュース、旅番組、ドキュメンタリー等）、映画系（歴史超大作、青春映画、ファンタジー等）、報道・現地リポート、ロケ・体験番組など多数のカテゴリに加え、`添付画像に写る世界についての動画` のように添付画像の世界観を動かす専用プリセットも選べます。
 
 > **注意**: `movie` 用プリセットを使う場合は、末尾プリセット用途を `movie` に切り替えてから選択してください。`image` のままだとJSONが正しく付与されません。
 
@@ -174,11 +176,13 @@ tails:
 | カメラ運動 | `mostly_static` / `gentle` / `continuous` |
 | 映像の活力 | `calm` / `vivid` / `intense` |
 | カット尺 | `uniform` / `weighted` / `variable` |
+| 完全実写映像 | ON で `live_action_only=true` |
+| 8K超高精細映像 | ON で `ultra_high_resolution_8k=true` |
 | 追加自由制約 | 上の専用項目にない条件だけを自然文で補足 |
 
 出力例:
 ```json
-{"direction_constraints":{"environment_scope":"outdoor_only","subject_tags":["outdoor_ruins","wildlife","coral reef"],"allow_still_frames":false,"camera_motion":"continuous","visual_energy":"vivid","cut_duration_policy":"variable","freeform_constraints":"Avoid modern urban elements."}}
+{"direction_constraints":{"environment_scope":"outdoor_only","subject_tags":["outdoor_ruins","wildlife","coral reef"],"allow_still_frames":false,"camera_motion":"continuous","visual_energy":"vivid","cut_duration_policy":"variable","live_action_only":true,"ultra_high_resolution_8k":true,"freeform_constraints":"Avoid modern urban elements."}}
 ```
 
 `環境` はプロンプト本文の内容に依存しにくい「場所・層」の指定だけに寄せています。`頻出対象` は視覚的に主役になりやすい対象群をまとめたもので、必要に応じて複数選択できます。

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 ### 動画生成向け
 - **末尾プリセット（movie）**: `{"video_style": ...}` JSON で動画スタイルを指定
 - **content_flags**: ナレーション・BGM・字幕・カット数などをJSONで付与
+- **用途別UI切替**: 末尾プリセット用途を `movie` にすると Midjourney 用「オプション」を非表示化
 - **JSON整形**: メインテキストを `world_description` や `storyboard` に変換
 - **LLM改良**: 世界観整形 / カオスミックス
 

--- a/app_image_prompt_creator_qt.py
+++ b/app_image_prompt_creator_qt.py
@@ -390,6 +390,8 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
             self.combo_direction_visual_energy,
             self.combo_direction_cut_duration_policy,
             self.entry_direction_freeform_constraints,
+            self.check_direction_live_action_only,
+            self.check_direction_ultra_high_resolution_8k,
         ]
         blockers = [QtCore.QSignalBlocker(widget) for widget in widgets]
         action_blockers = [
@@ -426,6 +428,10 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
                 defaults.get("cut_duration_policy", ""),
             )
             self.entry_direction_freeform_constraints.setText(str(defaults.get("freeform_constraints", "")).strip())
+            self.check_direction_live_action_only.setChecked(bool(defaults.get("live_action_only", False)))
+            self.check_direction_ultra_high_resolution_8k.setChecked(
+                bool(defaults.get("ultra_high_resolution_8k", False))
+            )
         finally:
             del action_blockers
             del blockers
@@ -840,6 +846,12 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
         freeform_constraints = self.entry_direction_freeform_constraints.text().strip()
         if freeform_constraints:
             constraints["freeform_constraints"] = freeform_constraints
+
+        if self.check_direction_live_action_only.isChecked():
+            constraints["live_action_only"] = True
+
+        if self.check_direction_ultra_high_resolution_8k.isChecked():
+            constraints["ultra_high_resolution_8k"] = True
 
         try:
             json_text = json.dumps({"direction_constraints": constraints}, ensure_ascii=False)

--- a/modules/config.py
+++ b/modules/config.py
@@ -162,6 +162,10 @@ DEFAULT_TAIL_PRESETS = {
     "movie": [
         {"description_ja": "（なし）", "prompt": ""},
         {
+            "description_ja": "添付画像に写る世界についての動画",
+            "prompt": "{\"video_style\":{\"scope\":\"full_movie\",\"description\":\"this is a cinematic video that expands the world shown in the attached image into a coherent moving scene, preserving its atmosphere, place, and visual logic\",\"source\":\"attached image world\"}}",
+        },
+        {
             "description_ja": "70mmフィルムのシネマティック全編",
             "prompt": "{\"video_style\":{\"scope\":\"full_movie\",\"description\":\"sweeping cinematic sequence shot on 70mm film\",\"look\":\"dramatic lighting\"}}",
         },

--- a/modules/prompt_data_mixins.py
+++ b/modules/prompt_data_mixins.py
@@ -150,6 +150,7 @@ class PromptDataMixin:
 
     def _on_tail_media_type_change(self, value: str):
         self._update_tail_free_text_choices(reset_selection=True)
+        self._sync_tail_media_type_visibility()
         self.auto_update()
 
     def _update_tail_free_text_choices(self, reset_selection: bool):

--- a/modules/prompt_text_utils.py
+++ b/modules/prompt_text_utils.py
@@ -377,6 +377,12 @@ def _compile_direction_constraints_to_sentences(direction_constraints: dict | No
     if isinstance(freeform_constraints, str) and freeform_constraints.strip():
         sentences.append(_ensure_sentence(freeform_constraints))
 
+    if direction_constraints.get("live_action_only") is True:
+        sentences.append("Render the entire video as fully live-action footage with no animated or illustrative look.")
+
+    if direction_constraints.get("ultra_high_resolution_8k") is True:
+        sentences.append("Render the entire video in ultra high resolution 8K quality.")
+
     return sentences
 
 

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -410,6 +410,24 @@ class PromptUIMixin:
         direction_row_4.addWidget(self.entry_direction_freeform_constraints, 1)
         direction_layout.addLayout(direction_row_4)
 
+        direction_row_5 = QtWidgets.QHBoxLayout()
+        # 映像の物理的な見え方に関する強い要件を、自由記述へ埋もれない専用フラグとして分離する。
+        self.check_direction_live_action_only = QtWidgets.QCheckBox("完全実写映像")
+        self.check_direction_live_action_only.setToolTip(
+            "ON にすると、CGアニメ調ではなく実写として成立する質感・撮影感を強く要求します。"
+        )
+        self.check_direction_live_action_only.stateChanged.connect(self.auto_update)
+        direction_row_5.addWidget(self.check_direction_live_action_only)
+
+        self.check_direction_ultra_high_resolution_8k = QtWidgets.QCheckBox("8K超高精細映像")
+        self.check_direction_ultra_high_resolution_8k.setToolTip(
+            "ON にすると、映像品質を 8K 相当の超高精細として強く要求します。"
+        )
+        self.check_direction_ultra_high_resolution_8k.stateChanged.connect(self.auto_update)
+        direction_row_5.addWidget(self.check_direction_ultra_high_resolution_8k)
+        direction_row_5.addStretch(1)
+        direction_layout.addLayout(direction_row_5)
+
         tail_form.addRow(direction_group)
         style_layout.addLayout(tail_form)
 

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -27,6 +27,14 @@ from modules.storyboard import (
 class PromptUIMixin:
     """UI構築とフォント制御を担当するミックスイン。"""
 
+    def _sync_tail_media_type_visibility(self) -> None:
+        """末尾プリセット用途に応じて、用途不一致の入力UIを隠す。"""
+
+        media_type = self.combo_tail_media_type.currentText() or config.DEFAULT_TAIL_MEDIA_TYPE
+        is_movie = media_type == "movie"
+        # movie では Midjourney オプションを使わないため、誤入力防止のために非表示にする。
+        self.group_midjourney_options.setVisible(not is_movie)
+
     def _build_ui(self):
         central = QtWidgets.QWidget()
         self.setCentralWidget(central)
@@ -405,14 +413,15 @@ class PromptUIMixin:
         tail_form.addRow(direction_group)
         style_layout.addLayout(tail_form)
 
-        mj_group = QtWidgets.QGroupBox("オプション")
-        mj_grid = QtWidgets.QGridLayout(mj_group)
+        self.group_midjourney_options = QtWidgets.QGroupBox("オプション")
+        mj_grid = QtWidgets.QGridLayout(self.group_midjourney_options)
         self.combo_tail_ar = self._add_option_cell(mj_grid, 0, "ar オプション:", config.AR_OPTIONS)
         self.combo_tail_s = self._add_option_cell(mj_grid, 1, "s オプション:", config.S_OPTIONS)
         self.combo_tail_chaos = self._add_option_cell(mj_grid, 2, "chaos オプション:", config.CHAOS_OPTIONS)
         self.combo_tail_q = self._add_option_cell(mj_grid, 3, "q オプション:", config.Q_OPTIONS)
         self.combo_tail_weird = self._add_option_cell(mj_grid, 4, "weird オプション:", config.WEIRD_OPTIONS)
-        style_layout.addWidget(mj_group)
+        style_layout.addWidget(self.group_midjourney_options)
+        self._sync_tail_media_type_visibility()
 
         style_layout.addStretch(1)
         tabs.addTab(style_tab, "スタイル・オプション")

--- a/tail_presets.yaml
+++ b/tail_presets.yaml
@@ -17,6 +17,9 @@ tails:
     - id: none
       description_ja: "（末尾の動画スタイル指定を付けない）"
       prompt: ""
+    - id: movie_attached_image_world
+      description_ja: "添付画像に写る世界についての動画"
+      prompt: "{\"video_style\":{\"scope\":\"full_movie\",\"description\":\"this is a cinematic video that expands the world shown in the attached image into a coherent moving scene, preserving its atmosphere, place, and visual logic\",\"source\":\"attached image world\"}}"
     # ---- シネマティック基礎スタイル（撮影・演出・編集テンプレ）----
     - id: section_movie_core
       description_ja: "===【カテゴリ】シネマティック基礎スタイル（撮影・演出・編集テンプレ）"

--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -298,6 +298,20 @@ def test_make_tail_flags_json_supports_explicit_zero_people(prompt_generator):
     assert payload["content_flags"]["person_count"] == 0
 
 
+def test_movie_tail_media_type_hides_midjourney_options(prompt_generator):
+    """movie 用途では、無効な Midjourney オプションUIを隠して誤操作を防ぐこと。"""
+
+    assert not prompt_generator.group_midjourney_options.isHidden()
+
+    prompt_generator.combo_tail_media_type.setCurrentText("movie")
+
+    assert prompt_generator.group_midjourney_options.isHidden()
+
+    prompt_generator.combo_tail_media_type.setCurrentText("image")
+
+    assert not prompt_generator.group_midjourney_options.isHidden()
+
+
 def test_update_option_does_not_restore_cleared_prompt(prompt_generator):
     """出力欄を空にした後の部分更新で、直前の本文が復活しないこと。"""
 

--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -269,6 +269,8 @@ def test_make_direction_constraints_json_from_ui(prompt_generator):
     prompt_generator.combo_direction_visual_energy.setCurrentText("生き生き")
     prompt_generator.combo_direction_cut_duration_policy.setCurrentText("可変")
     prompt_generator.entry_direction_freeform_constraints.setText("Avoid modern urban elements.")
+    prompt_generator.check_direction_live_action_only.setChecked(True)
+    prompt_generator.check_direction_ultra_high_resolution_8k.setChecked(True)
 
     payload = qt_app.json.loads(prompt_generator._make_direction_constraints_json().strip())
 
@@ -281,9 +283,28 @@ def test_make_direction_constraints_json_from_ui(prompt_generator):
             "visual_energy": "vivid",
             "cut_duration_policy": "variable",
             "freeform_constraints": "Avoid modern urban elements.",
+            "live_action_only": True,
+            "ultra_high_resolution_8k": True,
         }
     }
     assert prompt_generator.label_direction_common_subjects.text() in ("水辺・水域 / 天体", "天体 / 水辺・水域")
+
+
+def test_movie_direction_constraints_compile_new_quality_flags():
+    """新しい演出制約フラグが instructions に自然文として反映されること。"""
+
+    from modules.prompt_text_utils import compile_movie_instructions
+
+    instructions = compile_movie_instructions(
+        None,
+        {
+            "live_action_only": True,
+            "ultra_high_resolution_8k": True,
+        },
+    )
+
+    assert "Render the entire video as fully live-action footage with no animated or illustrative look." in instructions
+    assert "Render the entire video in ultra high resolution 8K quality." in instructions
 
 
 def test_make_tail_flags_json_supports_explicit_zero_people(prompt_generator):
@@ -310,6 +331,15 @@ def test_movie_tail_media_type_hides_midjourney_options(prompt_generator):
     prompt_generator.combo_tail_media_type.setCurrentText("image")
 
     assert not prompt_generator.group_midjourney_options.isHidden()
+
+
+def test_movie_tail_preset_contains_attached_image_world_option(prompt_generator):
+    """movie 末尾1に、添付画像の世界を動画化する専用プリセットが存在すること。"""
+
+    prompt_generator.combo_tail_media_type.setCurrentText("movie")
+    labels = [prompt_generator.combo_tail_free.itemText(i) for i in range(prompt_generator.combo_tail_free.count())]
+
+    assert "添付画像に写る世界についての動画" in labels
 
 
 def test_update_option_does_not_restore_cleared_prompt(prompt_generator):


### PR DESCRIPTION
## Summary
- movie 用途では無効な Midjourney 用オプショングループを非表示にし、用途に対して自然な UI に揃えました。
- movie の末尾1に「添付画像に写る世界についての動画」プリセットを追加し、添付画像の世界観をそのまま動画化する導線を増やしました。
- direction_constraints に live_action_only と ultra_high_resolution_8k を追加し、「完全実写映像」と「8K超高精細映像」を UI から明示的に制約できるようにしました。

## Why
- これまで movie 用途でも Midjourney 系オプションが表示されており、動画生成では意味を持たない入力が UI に残っていました。これは用途別 UI の責務が曖昧で、誤操作や誤解を招く状態でした。
- また、添付画像の世界を起点に動画へ展開したいケースに対して、専用の movie プリセットがなく、毎回手入力や近似プリセットへの置き換えが必要でした。
- 演出制約についても、実写限定や 8K 品質のような強い要求を専用フィールドで持てず、自由記述へ寄せるしかありませんでした。今回の変更で UI、JSON 契約、自然文 instructions の整合を取っています。

## Design Notes
- UI 構築は PromptUIMixin、既定値適用と JSON 化は PromptGeneratorWindow、自然文補助化は prompt_text_utils に分け、既存の責務分離を維持しました。
- 新しい品質系制約は自由記述ではなく direction_constraints の boolean として追加し、プリセット既定値、JSON 出力、LLM 補助文の各経路で同じ契約を使うようにしています。
- tail_presets.yaml に加えて modules/config.py のフォールバック定義にも同じ movie プリセットを追加し、YAML 読込失敗時でも UI 契約が崩れないようにしました。

## User Impact
- movie を選んだとき、不要な Midjourney オプションは表示されません。
- movie の末尾1から、添付画像の世界観を前提にした動画スタイルを直接選択できます。
- 演出制約で「完全実写映像」と「8K超高精細映像」を個別に指定でき、その内容は direction_constraints と video_prompt.instructions の両方に反映されます。

## Test Plan
- python -m pytest tests/test_generate_text_qt.py
- movie 用途切替で Midjourney オプションが非表示になることを確認
- direction_constraints UI から新フラグが JSON に出力されることを確認
- 新しい品質系フラグが instructions 向け自然文へ変換されることを確認
- movie 末尾1に新プリセットが表示されることを確認

## Docs
- Docs: updated
- README.md に以下を反映しました。
- movie 用途では Midjourney 用オプションを非表示にすること
- 「添付画像に写る世界についての動画」プリセットの追加
- 「完全実写映像」/「8K超高精細映像」の direction_constraints 仕様と JSON 例