### PR TITLE
ペインのリサイズ挙動と属性選択セクションの挙動を改善

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,25 @@ python app_image_prompt_creator_qt.py
 # テスト
 python -m pytest tests/test_generate_text_qt.py -v
 
+# UIレイアウト/Qt挙動まわりを重点確認
+python -m pytest tests/test_generate_text_qt.py -k "splitter or attribute" -v
+
 # 必須ファイル確認
 python scripts/check_required_files.py
 ```
+
+## Testing Policy
+
+- UIに限らず、改修時は「何が壊れていたか」を先に言語化し、その失敗を再現できるテストを優先して追加する
+- 不具合修正では、対症療法ではなく根本原因を検知できる観点でテストを書く
+- 新機能追加では、正例だけでなく主要な境界値・無効入力・回帰リスクも最低1つ確認する
+- 既存不具合の再発防止として、修正コードだけでなく利用者操作や公開メソッド経由でも期待どおりになるかを確認する
+- 完了報告前に、変更範囲に関係するテストを実行し、実行していない場合は未実行であることを明示する
+- このリポジトリでは少なくとも `python -m pytest tests/test_generate_text_qt.py -v` を実行候補として確認する
+- PySide6 のUI改修では、見た目だけで完了扱いにせず `tests/test_generate_text_qt.py` に再現テストを追加する
+- レイアウト不具合では `isVisible()` だけでなく `sizes()` / `height()` / ハンドルのドラッグ結果まで確認する
+- `QSplitter` の不具合確認では `moveSplitter()` だけでなく、可能なら `QtTest.QTest` で実ドラッグも検証する
+- 折りたたみUIでは「展開時」「格納時」「格納後も仕切り操作可能か」を別ケースで確認する
 
 ## Project Structure
 

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -138,8 +138,17 @@ class PromptUIMixin:
         attr_body.setVisible(False)
         attr_container.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum)
         attr_container.setMinimumHeight(0)
-        attr_container.setMaximumHeight(self._get_attr_collapsed_height())
+        self._refresh_attr_group_collapsed_height()
         attr_container.updateGeometry()
+
+    def _refresh_attr_group_collapsed_height(self) -> None:
+        """属性選択が格納状態のときに、ヘッダ高に合わせて最大高さを再計算する。"""
+        attr_container = getattr(self, "attr_section_container", None)
+        attr_toggle = getattr(self, "attr_toggle_button", None)
+        if attr_container is None or attr_toggle is None:
+            return
+
+        attr_container.setMaximumHeight(self._get_attr_collapsed_height())
 
     def _get_attr_collapsed_height(self) -> int:
         """属性選択セクションを格納したときの高さを返す。"""
@@ -1923,6 +1932,10 @@ class PromptUIMixin:
             }}
         """
         )
+
+        if hasattr(self, "attr_toggle_button") and self.attr_toggle_button is not None:
+            if not self.attr_toggle_button.isChecked():
+                self._refresh_attr_group_collapsed_height()
 
         self._update_font_button_label(preset["label"])
 

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -103,6 +103,15 @@ class PromptUIMixin:
         self.button_font_scale.clicked.connect(self.cycle_font_scale)
         header_layout.addWidget(self.button_font_scale)
 
+    def _on_attr_group_toggled(self, checked: bool) -> None:
+        """属性選択セクションの折りたたみ状態を切り替える。
+
+        GroupBox 自体は常に表示しつつ、中身のスクロールエリアだけを表示/非表示にする。
+        これにより、タイトル行をクリックして展開できる「折りたたみセクション」として扱える。
+        """
+        if hasattr(self, "attribute_area") and self.attribute_area is not None:
+            self.attribute_area.setVisible(checked)
+
     def _build_left_pane_content(self, layout):
         basic_group = QtWidgets.QGroupBox("基本設定")
         basic_grid = QtWidgets.QGridLayout(basic_group)
@@ -175,15 +184,23 @@ class PromptUIMixin:
 
         layout.addWidget(basic_group)
 
-        attr_group = QtWidgets.QGroupBox("属性選択")
-        attr_layout = QtWidgets.QVBoxLayout(attr_group)
+        self.attr_group = QtWidgets.QGroupBox("属性選択")
+        self.attr_group.setCheckable(True)
+        # デフォルトでは折りたたみ状態とし、必要なときだけ展開して使う。
+        self.attr_group.setChecked(False)
+        self.attr_group.toggled.connect(self._on_attr_group_toggled)
+
+        attr_layout = QtWidgets.QVBoxLayout(self.attr_group)
         self.attribute_area = QtWidgets.QScrollArea()
         self.attribute_area.setWidgetResizable(True)
         self.attribute_container = QtWidgets.QWidget()
         self.attribute_layout = QtWidgets.QFormLayout(self.attribute_container)
         self.attribute_area.setWidget(self.attribute_container)
         attr_layout.addWidget(self.attribute_area)
-        layout.addWidget(attr_group, 1)
+        layout.addWidget(self.attr_group, 1)
+
+        # 初期状態の折りたたみ反映
+        self._on_attr_group_toggled(self.attr_group.isChecked())
 
         tabs = QtWidgets.QTabWidget()
         layout.addWidget(tabs)

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -46,6 +46,10 @@ class PromptUIMixin:
         self._build_header(main_layout)
 
         splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        # 左右ペインの幅をドラッグで柔軟に調整できるようにする設定。
+        splitter.setOpaqueResize(True)
+        splitter.setChildrenCollapsible(False)
+        splitter.setHandleWidth(6)
         main_layout.addWidget(splitter, 1)
 
         left_widget = QtWidgets.QWidget()
@@ -62,8 +66,11 @@ class PromptUIMixin:
         self._build_right_pane_content(right_layout)
         splitter.addWidget(right_widget)
 
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 6)
+        # 初期比率は 1:2 としつつ、どちらのペインも十分に狭くできるよう最小幅を抑えておく。
+        left_widget.setMinimumWidth(220)
+        right_widget.setMinimumWidth(280)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 2)
 
         self.status_bar = self.statusBar()
         self.loading_progress = QtWidgets.QProgressBar()

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -23,6 +23,8 @@ from modules.storyboard import (
     extract_metadata_from_prompt,
 )
 
+WIDGET_SIZE_MAX = 16777215
+
 
 class PromptUIMixin:
     """UI構築とフォント制御を担当するミックスイン。"""
@@ -111,17 +113,78 @@ class PromptUIMixin:
         header_layout.addWidget(self.button_font_scale)
 
     def _on_attr_group_toggled(self, checked: bool) -> None:
-        """属性選択セクションの折りたたみ状態を切り替える。
+        """属性選択セクションの折りたたみ状態を切り替える。"""
+        attr_container = getattr(self, "attr_section_container", None)
+        attr_body = getattr(self, "attr_body_container", None)
+        attr_toggle = getattr(self, "attr_toggle_button", None)
+        if attr_container is None or attr_body is None or attr_toggle is None:
+            return
 
-        GroupBox 自体は常に表示しつつ、中身のスクロールエリアだけを表示/非表示にする。
-        これにより、タイトル行をクリックして展開できる「折りたたみセクション」として扱える。
-        """
-        if hasattr(self, "attribute_area") and self.attribute_area is not None:
-            self.attribute_area.setVisible(checked)
+        if checked:
+            attr_toggle.setArrowType(QtCore.Qt.DownArrow)
+            attr_body.setVisible(True)
+            attr_container.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)
+            attr_container.setMinimumHeight(160)
+            attr_container.setMaximumHeight(WIDGET_SIZE_MAX)
+            attr_container.updateGeometry()
+            self._schedule_left_splitter_resize(expanded=True)
+            return
+
+        current_height = attr_container.height()
+        if current_height > 80:
+            self._attr_group_expanded_height = current_height
+
+        attr_toggle.setArrowType(QtCore.Qt.RightArrow)
+        attr_body.setVisible(False)
+        attr_container.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum)
+        attr_container.setMinimumHeight(0)
+        attr_container.setMaximumHeight(self._get_attr_collapsed_height())
+        attr_container.updateGeometry()
+
+    def _get_attr_collapsed_height(self) -> int:
+        """属性選択セクションを格納したときの高さを返す。"""
+        attr_toggle = getattr(self, "attr_toggle_button", None)
+        if attr_toggle is not None:
+            return attr_toggle.sizeHint().height() + 8
+        return 36
+
+    def _schedule_left_splitter_resize(self, expanded: bool) -> None:
+        """レイアウト反映後に左スプリッタの高さ配分を調整する。"""
+        QtCore.QTimer.singleShot(0, lambda: self._resize_left_splitter(expanded))
+
+    def _resize_left_splitter(self, expanded: bool) -> None:
+        """属性選択の展開状態に応じて左スプリッタの高さ配分を整える。"""
+        splitter = getattr(self, "left_splitter", None)
+        attr_container = getattr(self, "attr_section_container", None)
+        if not isinstance(splitter, QtWidgets.QSplitter) or splitter.count() != 2 or attr_container is None:
+            return
+
+        total = max(1, splitter.height())
+        left_tabs = getattr(self, "left_tabs", None)
+        lower_min = 24
+        if isinstance(left_tabs, QtWidgets.QTabWidget):
+            # タブ本文はスプリッタで十分に縮められる前提とし、最低限タブバーが見える量だけ確保する。
+            lower_min = max(lower_min, left_tabs.tabBar().sizeHint().height() + 6)
+
+        if expanded:
+            preferred = getattr(self, "_attr_group_expanded_height", 0) or 0
+            minimum_expanded = max(220, attr_container.sizeHint().height(), 160)
+            upper = max(minimum_expanded, preferred)
+            # 展開時は下側タブの最低表示量だけ確保し、残りはできるだけ属性選択へ配分する。
+            upper = min(total - lower_min, upper)
+        else:
+            # 格納時は属性選択セクション自体だけを最小化し、スプリッタ位置は固定しない。
+            sizes = splitter.sizes()
+            upper = sizes[0] if sizes else self._get_attr_collapsed_height()
+
+        upper = max(1, upper)
+        lower = max(1, total - upper)
+        splitter.setSizes([upper, lower])
 
     def _build_left_pane_content(self, layout):
-        basic_group = QtWidgets.QGroupBox("基本設定")
-        basic_grid = QtWidgets.QGridLayout(basic_group)
+        self.basic_group = QtWidgets.QGroupBox("基本設定")
+        self.basic_group.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum)
+        basic_grid = QtWidgets.QGridLayout(self.basic_group)
 
         basic_grid.addWidget(QtWidgets.QLabel("行数:"), 0, 0)
         self.spin_row_num = QtWidgets.QSpinBox()
@@ -189,28 +252,63 @@ class PromptUIMixin:
         self.radio_mode_llm.toggled.connect(self._update_generate_mode_ui)
         self._update_generate_mode_ui()
 
-        layout.addWidget(basic_group)
+        layout.addWidget(self.basic_group)
 
-        self.attr_group = QtWidgets.QGroupBox("属性選択")
-        self.attr_group.setCheckable(True)
-        # デフォルトでは折りたたみ状態とし、必要なときだけ展開して使う。
-        self.attr_group.setChecked(False)
-        self.attr_group.toggled.connect(self._on_attr_group_toggled)
+        # 属性選択とスタイル/データ管理だけを縦方向スプリッタで分割する。
+        # 基本設定は固定高のまま上部に置き、不要な余白やつぶれを防ぐ。
+        self.left_splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        self.left_splitter.setOpaqueResize(True)
+        # 下側のタブ群は内容が多く最小サイズヒントが大きくなりやすいため、
+        # スプリッタでは縮められるようにして上側の属性選択を圧迫しないようにする。
+        self.left_splitter.setChildrenCollapsible(True)
+        self.left_splitter.setHandleWidth(6)
+        layout.addWidget(self.left_splitter, 1)
 
-        attr_layout = QtWidgets.QVBoxLayout(self.attr_group)
+        self.attr_section_container = QtWidgets.QWidget()
+        self.attr_section_container.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)
+        attr_container_layout = QtWidgets.QVBoxLayout(self.attr_section_container)
+        attr_container_layout.setContentsMargins(0, 0, 0, 0)
+        attr_container_layout.setSpacing(6)
+
+        # checkable QGroupBox は sizeHint が不安定になりやすいため、
+        # ヘッダボタンと本文コンテナを分離して折りたたみを管理する。
+        self.attr_toggle_button = QtWidgets.QToolButton()
+        self.attr_toggle_button.setText("属性選択")
+        self.attr_toggle_button.setCheckable(True)
+        self.attr_toggle_button.setChecked(False)
+        self.attr_toggle_button.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
+        self.attr_toggle_button.setArrowType(QtCore.Qt.RightArrow)
+        self.attr_toggle_button.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed)
+        self.attr_toggle_button.toggled.connect(self._on_attr_group_toggled)
+        attr_container_layout.addWidget(self.attr_toggle_button)
+
+        self.attr_body_container = QtWidgets.QGroupBox()
+        self.attr_body_container.setTitle("")
+        self.attr_body_container.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)
+        attr_layout = QtWidgets.QVBoxLayout(self.attr_body_container)
+        attr_layout.setContentsMargins(8, 12, 8, 8)
         self.attribute_area = QtWidgets.QScrollArea()
         self.attribute_area.setWidgetResizable(True)
+        self.attribute_area.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)
         self.attribute_container = QtWidgets.QWidget()
         self.attribute_layout = QtWidgets.QFormLayout(self.attribute_container)
         self.attribute_area.setWidget(self.attribute_container)
         attr_layout.addWidget(self.attribute_area)
-        layout.addWidget(self.attr_group, 1)
+        attr_container_layout.addWidget(self.attr_body_container, 1)
+        self.left_splitter.addWidget(self.attr_section_container)
 
         # 初期状態の折りたたみ反映
-        self._on_attr_group_toggled(self.attr_group.isChecked())
+        self._on_attr_group_toggled(self.attr_toggle_button.isChecked())
 
-        tabs = QtWidgets.QTabWidget()
-        layout.addWidget(tabs)
+        self.left_tabs = QtWidgets.QTabWidget()
+        self.left_tabs.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Ignored)
+        self.left_tabs.setMinimumHeight(0)
+        self.left_splitter.addWidget(self.left_tabs)
+        self.left_splitter.setCollapsible(0, True)
+        self.left_splitter.setCollapsible(1, True)
+        self.left_splitter.setStretchFactor(0, 1)
+        self.left_splitter.setStretchFactor(1, 1)
+        self._schedule_left_splitter_resize(expanded=False)
 
         style_tab = QtWidgets.QWidget()
         style_layout = QtWidgets.QVBoxLayout(style_tab)
@@ -466,7 +564,7 @@ class PromptUIMixin:
         self._sync_tail_media_type_visibility()
 
         style_layout.addStretch(1)
-        tabs.addTab(style_tab, "スタイル・オプション")
+        self.left_tabs.addTab(style_tab, "スタイル・オプション")
 
         data_tab = QtWidgets.QWidget()
         data_layout = QtWidgets.QVBoxLayout(data_tab)
@@ -500,7 +598,7 @@ class PromptUIMixin:
         data_layout.addWidget(db_group)
 
         data_layout.addStretch(1)
-        tabs.addTab(data_tab, "データ管理")
+        self.left_tabs.addTab(data_tab, "データ管理")
 
     def _add_option_cell(self, grid: QtWidgets.QGridLayout, row: int, label: str, values: Iterable[str]) -> QtWidgets.QComboBox:
         """グリッドレイアウトにオプション項目を追加するヘルパー。"""

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -511,10 +511,20 @@ class PromptUIMixin:
         return combo
 
     def _build_right_pane_content(self, layout):
+        # プロンプトテキストとツール群の縦幅をユーザーが調整できるように、
+        # 右ペインは縦方向の QSplitter で分割する。
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        layout.addWidget(splitter, 1)
+
+        # 上側: 出力テキスト + アクションボタン
+        upper_widget = QtWidgets.QWidget()
+        upper_layout = QtWidgets.QVBoxLayout(upper_widget)
+        upper_layout.setContentsMargins(0, 0, 0, 0)
+
         self.text_output = QtWidgets.QTextEdit()
         self.text_output.setAcceptRichText(False)
         self.text_output.setPlaceholderText("ここに生成結果が表示されます")
-        layout.addWidget(self.text_output, 1)
+        upper_layout.addWidget(self.text_output, 1)
 
         action_layout = QtWidgets.QHBoxLayout()
 
@@ -530,7 +540,7 @@ class PromptUIMixin:
         generate_copy_btn.clicked.connect(self.generate_and_copy)
         action_layout.addWidget(generate_copy_btn, 1)
 
-        layout.addLayout(action_layout)
+        upper_layout.addLayout(action_layout)
 
         sub_action_layout = QtWidgets.QHBoxLayout()
 
@@ -547,11 +557,22 @@ class PromptUIMixin:
         update_option_btn.clicked.connect(lambda _checked=False: self.update_option())
         sub_action_layout.addWidget(update_option_btn)
 
-        layout.addLayout(sub_action_layout)
+        upper_layout.addLayout(sub_action_layout)
+
+        splitter.addWidget(upper_widget)
+
+        # 下側: 各種ツールタブ
+        lower_widget = QtWidgets.QWidget()
+        lower_layout = QtWidgets.QVBoxLayout(lower_widget)
+        lower_layout.setContentsMargins(0, 0, 0, 0)
 
         tools_tabs = QtWidgets.QTabWidget()
         tools_tabs.setMinimumHeight(320)
-        layout.addWidget(tools_tabs)
+        lower_layout.addWidget(tools_tabs)
+
+        splitter.addWidget(lower_widget)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 2)
 
         movie_tab = QtWidgets.QWidget()
         movie_layout = QtWidgets.QVBoxLayout(movie_tab)

--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 PySide6 = pytest.importorskip("PySide6")
-from PySide6 import QtWidgets
+from PySide6 import QtCore, QtTest, QtWidgets
 
 # repo root から pytest を実行しても import が崩れないよう、app_image_prompt_creator を明示的に sys.path へ追加する。
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -95,6 +95,15 @@ def prompt_generator(tmp_path, monkeypatch, qt_application):
     window.close()
 
 
+def _process_events() -> None:
+    """Qt の遅延レイアウト更新を反映させる。"""
+    app = QtWidgets.QApplication.instance()
+    assert app is not None
+    app.processEvents()
+    QtCore.QThread.msleep(10)
+    app.processEvents()
+
+
 def test_generate_text_uses_selected_attribute_id(prompt_generator):
     """同じ説明文の属性から、IDで指定したほうのみ抽出されることを確認する。"""
 
@@ -108,6 +117,143 @@ def test_generate_text_uses_selected_attribute_id(prompt_generator):
 
     assert "Second prompt." in prompt_generator.main_prompt
     assert "First prompt" not in prompt_generator.main_prompt
+
+
+def test_attribute_section_toggle_changes_visible_height(prompt_generator):
+    """属性選択は展開時に十分な高さを持ち、格納時に最小化されること。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    collapsed_height = prompt_generator.attr_section_container.height()
+    assert collapsed_height <= 60
+    assert not prompt_generator.attr_body_container.isVisible()
+
+    prompt_generator.attr_toggle_button.click()
+    _process_events()
+
+    expanded_height = prompt_generator.attr_section_container.height()
+    assert prompt_generator.attr_body_container.isVisible()
+    assert expanded_height >= 140
+    assert expanded_height > collapsed_height + 60
+
+    prompt_generator.attr_toggle_button.click()
+    _process_events()
+
+    collapsed_again_height = prompt_generator.attr_section_container.height()
+    assert not prompt_generator.attr_body_container.isVisible()
+    assert collapsed_again_height < expanded_height
+    assert collapsed_again_height <= 60
+
+
+def test_left_splitter_can_change_sizes_when_attribute_section_expanded(prompt_generator):
+    """左スプリッタは展開後も上下サイズを変更できること。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    if not prompt_generator.attr_toggle_button.isChecked():
+        prompt_generator.attr_toggle_button.click()
+        _process_events()
+
+    splitter = prompt_generator.left_splitter
+    before = splitter.sizes()
+    total = sum(before)
+    assert total > 0
+
+    target_upper = min(total - 40, before[0] + 80)
+    splitter.moveSplitter(target_upper, 1)
+    _process_events()
+
+    after = splitter.sizes()
+    assert after != before
+    assert abs(after[0] - target_upper) <= 40
+
+
+def test_left_splitter_handle_drag_moves_down_when_attribute_section_expanded(prompt_generator):
+    """左スプリッタのハンドルを実際にドラッグすると下方向へ移動できること。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    if not prompt_generator.attr_toggle_button.isChecked():
+        prompt_generator.attr_toggle_button.click()
+        _process_events()
+
+    splitter = prompt_generator.left_splitter
+    before = splitter.sizes()
+    handle = splitter.handle(1)
+    assert handle is not None
+
+    center = handle.rect().center()
+    drag_target = center + QtCore.QPoint(0, 80)
+    QtTest.QTest.mousePress(handle, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier, center)
+    QtTest.QTest.mouseMove(handle, drag_target, delay=20)
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier, drag_target, delay=20)
+    _process_events()
+
+    after = splitter.sizes()
+    assert after != before
+    assert after[0] > before[0]
+
+
+def test_collapsed_attribute_section_keeps_minimal_height_without_forcing_splitter(prompt_generator):
+    """属性選択を格納しても、最小化されるのは属性セクションだけでスプリッタ位置は固定しないこと。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    if not prompt_generator.attr_toggle_button.isChecked():
+        prompt_generator.attr_toggle_button.click()
+        _process_events()
+
+    splitter = prompt_generator.left_splitter
+    splitter.moveSplitter(260, 1)
+    _process_events()
+    expanded_sizes = splitter.sizes()
+    expanded_height = prompt_generator.attr_section_container.height()
+
+    prompt_generator.attr_toggle_button.click()
+    _process_events()
+
+    collapsed_sizes = splitter.sizes()
+    collapsed_height = prompt_generator.attr_section_container.height()
+
+    assert not prompt_generator.attr_body_container.isVisible()
+    assert collapsed_height <= 60
+    assert collapsed_height < expanded_height
+    assert abs(collapsed_sizes[0] - expanded_sizes[0]) <= 20
+    assert abs(collapsed_sizes[1] - expanded_sizes[1]) <= 20
+
+
+def test_left_splitter_handle_drag_moves_when_attribute_section_collapsed(prompt_generator):
+    """属性選択が格納状態でも、左スプリッタのハンドルを下方向へドラッグできること。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    assert not prompt_generator.attr_toggle_button.isChecked()
+
+    splitter = prompt_generator.left_splitter
+    before = splitter.sizes()
+    handle = splitter.handle(1)
+    assert handle is not None
+
+    center = handle.rect().center()
+    drag_target = center + QtCore.QPoint(0, 80)
+    QtTest.QTest.mousePress(handle, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier, center)
+    QtTest.QTest.mouseMove(handle, drag_target, delay=20)
+    QtTest.QTest.mouseRelease(handle, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier, drag_target, delay=20)
+    _process_events()
+
+    after = splitter.sizes()
+    assert after != before
+    assert after[0] > before[0]
 
 
 def test_storyboard_duration_allocation_prompt_llm_contains_duration_rules(qt_application):

--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -147,6 +147,31 @@ def test_attribute_section_toggle_changes_visible_height(prompt_generator):
     assert collapsed_again_height <= 60
 
 
+def test_collapsed_attribute_section_recomputes_height_after_font_scale(prompt_generator):
+    """格納状態でフォント変更しても、ヘッダが欠けない高さに再計算されること。"""
+
+    prompt_generator.resize(420, 900)
+    prompt_generator.show()
+    _process_events()
+
+    assert not prompt_generator.attr_toggle_button.isChecked()
+
+    initial_max_height = prompt_generator.attr_section_container.maximumHeight()
+    initial_button_height = prompt_generator.attr_toggle_button.sizeHint().height()
+    assert initial_max_height >= initial_button_height
+
+    # 複数回切り替えて確実に大きいフォントへ到達させる。
+    for _ in range(max(2, len(qt_app.config.FONT_SCALE_PRESETS))):
+        prompt_generator.cycle_font_scale()
+    _process_events()
+
+    scaled_max_height = prompt_generator.attr_section_container.maximumHeight()
+    scaled_button_height = prompt_generator.attr_toggle_button.sizeHint().height()
+
+    assert scaled_button_height >= initial_button_height
+    assert scaled_max_height >= scaled_button_height
+
+
 def test_left_splitter_can_change_sizes_when_attribute_section_expanded(prompt_generator):
     """左スプリッタは展開後も上下サイズを変更できること。"""
 


### PR DESCRIPTION
﻿## 概要
- 属性選択セクションをデフォルトで折りたたみ化し、左ペイン内での開閉挙動を調整
- プロンプト領域と左ペインのリサイズ挙動を改善し、仕切り操作まわりの挙動を見直し
- 属性選択トグルとスプリッタ挙動の Qt 回帰テストを追加し、AGENTS.md にテスト方針を追記

## テスト
- [x] python -m pytest tests/test_generate_text_qt.py -v
- [x] python -m pytest tests/test_generate_text_qt.py -k "splitter or attribute" -v

No-Docs-Change: README の仕様変更はありません。開発運用ルールとして AGENTS.md のみ更新しました。
