### PR TITLE
Soraメタデータをmode enumへ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ### 動画生成向け
 - **末尾プリセット（movie）**: `{"video_style": ...}` JSON で動画スタイルを指定
 - **添付画像世界トグル**: ON にすると、添付画像に写る世界を動画として展開する要件を `video_style.description` の先頭へ付与
-- **content_flags**: ナレーション・BGM・字幕・カット数などをJSONで付与
+- **content_flags**: ナレーション・BGM詳細・字幕・カット数などをJSONで付与
 - **用途別UI切替**: 末尾プリセット用途を `movie` にすると Midjourney 用「オプション」を非表示化
 - **演出制約の品質指定**: `完全実写映像` と `8K超高精細映像` を個別にON/OFF可能
 - **JSON整形**: メインテキストを `world_description` や `storyboard` に変換
@@ -98,7 +98,7 @@ python app_image_prompt_creator/app_image_prompt_creator_qt.py
 [属性選択] → [movie プリセット] → [content_flags] → [生成] → [JSON整形] → [コピー]
 ```
 
-末尾プリセット `movie` で `{"video_style":...}` を選び、必要なら `添付画像に写る世界についての動画` を ON にして `video_style.description` の先頭へ要件を付与します。content_flags でナレーション・BGM・カット数などを設定して生成できます。生成後、「動画用に整形(JSON)」パネルで「世界観整形」や「カオスミックス」を実行できます。ストーリーボード（複数カット）は「ストーリーボード」タブで生成・編集します。
+末尾プリセット `movie` で `{"video_style":...}` を選び、必要なら `添付画像に写る世界についての動画` を ON にして `video_style.description` の先頭へ要件を付与します。content_flags でナレーション・BGM詳細・カット数などを設定して生成できます。生成後、「動画用に整形(JSON)」パネルで「世界観整形」や「カオスミックス」を実行できます。ストーリーボード（複数カット）は「ストーリーボード」タブで生成・編集します。
 
 ---
 
@@ -135,7 +135,7 @@ tails:
 
 `description_ja` はUI表示専用です。`prompt` は `video_style` の実体です。`content_flags_defaults` / `direction_constraints_defaults` は任意項目で、定義したプリセットだけが選択時に UI へ既定値を反映します。アプリ起動中にYAMLを保存すると自動でリロードされます。
 
-なお、`content_flags` や `direction_constraints` のうち動画モデルが解釈しづらい項目（`false` 系フラグ、対象タグ、自由制約など）は、最終出力時に `video_prompt.instructions` へ自然文の配列として自動展開されます。`video_prompt.prompt` 本文は汚さず、構造化JSONと自然文の補助情報を分離する設計です。
+なお、`content_flags` や `direction_constraints` は、`false` を多用したブール表現ではなく、`*_mode` や `*_policy` のような意味の強い値で保持します。送信用JSONでは `video_prompt.instructions` を持たず、重複する自然文を省いた構造化JSONをそのまま出力します。
 
 ---
 
@@ -147,18 +147,27 @@ tails:
 |------|------|
 | 末尾2を反映 | マスタースイッチ。ONにしないとJSONは付与されません |
 | ナレーション / BGM / 環境音 | 音声要素の有無 |
+| BGM詳細 | BGM を ON にした時だけ使う追加指定（ジャンル / 雰囲気 / テンポ / ボーカル / 同期 / 追加メモ） |
 | 人物 / 人物のセリフ | 映像内の人物とセリフの有無 |
 | セリフ字幕 / テロップ | 画面上のテキスト要素 |
-| 登場人物 | なし / 0人 / 1+ / 1〜4 / many（群衆） |
+| 登場人物 | `person_mode` として `no_people` / `at_least_one_person` / `one_person` / `two_people` / `three_people` / `four_people` / `crowd` を出力 |
 | 構成カット数 | Auto / 1〜15 / many（高速モンタージュ） |
 | 動画中の言語 | Auto / 日本語 / 英語 |
 
 出力例:
 ```json
-{"content_flags":{"narration":true,"bgm":true,"ambient_sound":true,"planned_cuts":3,"spoken_language":"ja"}}
+{"content_flags":{"narration_mode":"with_narration","bgm_mode":"with_bgm","bgm_genre":"cinematic","bgm_mood":"melancholic","bgm_tempo":"slow","bgm_vocal":"instrumental","bgm_sync":"beat_matched","ambient_sound_mode":"with_ambient_sound","dialogue_mode":"no_dialogue","person_mode":"two_people","planned_cuts":3,"speech_language":"ja"}}
 ```
 
-`(なし)` は人物なしを示しつつ人数は未指定のままにします。`0人` は `person_present=false` に加えて `person_count=0` を出力し、明示的に人物ゼロを指定します。
+`(なし)` は人物条件を出力しません。`0人` は `person_mode="no_people"` を出力し、明示的に人物ゼロを指定します。
+
+プルダウンの表記は日本語で、JSON には英語トークンが入ります。`bgm_mode="with_bgm"` のときだけ BGM 詳細が出力され、BGM が無効のまま詳細だけを指定しても JSON には反映されません。
+
+負例:
+```json
+{"content_flags":{"bgm_genre":"cinematic","bgm_mood":"melancholic"}}
+```
+→ `bgm_mode="with_bgm"` でないため、BGM 詳細は出力されません。
 
 ---
 
@@ -172,27 +181,27 @@ tails:
 | 環境 | `indoor_only` / `outdoor_only` / `indoor_outdoor_mixed` / `underground` / `underwater` / `water_surface` / `aerial` / `space` |
 | 頻出対象 | `選択` メニューから `建築物` / `室内空間` / `都市インフラ` / `屋外の遺跡` / `地形・岩場` / `植物` / `水辺・水域` / `野生生物` / `乗り物` / `機械` / `天体` を複数選択できます |
 | 追加対象タグ | 頻出対象にないものだけをカンマ区切りで追加します。例: `coral reef, volcanic landscape` |
-| 静止画カットを許可 | OFF で `allow_still_frames=false` |
+| 静止画カットを許可 | OFF で `still_frame_policy="forbid"` |
 | カメラ運動 | `mostly_static` / `gentle` / `continuous` |
 | 映像の活力 | `calm` / `vivid` / `intense` |
 | カット尺 | `uniform` / `weighted` / `variable` |
-| 主役 | `people_primary` / `scene_primary`。人物が映る場合でも、人物主体か情景主体かを明示します |
-| 完全実写映像 | ON で `live_action_only=true` |
-| 8K超高精細映像 | ON で `ultra_high_resolution_8k=true` |
+| 主役 | `focus_priority` として `people` / `scene` を出力。人物が映る場合でも、人物主体か情景主体かを明示します |
+| 完全実写映像 | ON で `render_style="live_action"` |
+| 8K超高精細映像 | ON で `resolution_tier="8k"` |
 | 追加自由制約 | 上の専用項目にない条件だけを自然文で補足 |
 
 出力例:
 ```json
-{"direction_constraints":{"environment_scope":"outdoor_only","subject_tags":["outdoor_ruins","wildlife","coral reef"],"allow_still_frames":false,"camera_motion":"continuous","visual_energy":"vivid","cut_duration_policy":"variable","subject_focus":"scene_primary","live_action_only":true,"ultra_high_resolution_8k":true,"freeform_constraints":"Avoid modern urban elements."}}
+{"direction_constraints":{"environment_scope":"outdoor_only","subject_tags":["outdoor_ruins","wildlife","coral reef"],"still_frame_policy":"forbid","camera_motion":"continuous","visual_energy":"vivid","cut_duration_policy":"variable","focus_priority":"scene","render_style":"live_action","resolution_tier":"8k","freeform_constraints":"Avoid modern urban elements."}}
 ```
 
 `環境` はプロンプト本文の内容に依存しにくい「場所・層」の指定だけに寄せています。`頻出対象` は視覚的に主役になりやすい対象群をまとめたもので、必要に応じて複数選択できます。`主役` は構図の中心を明示するための項目で、人物が複数いても `情景主体` を選ぶと背景・空間・風景を優先した画作りを促します。
 
-正例: 人物が2人以上登場しても風景や建築を主役にしたい場合は `主役=scene_primary` を選びます。
+正例: 人物が2人以上登場しても風景や建築を主役にしたい場合は `主役=scene` を選びます。
 
 負例: 人物が映るだけで常に人物中心の構図にしたくない場面で、`主役` を未指定のままにするとモデル判断で人物主体へ寄ることがあります。
 
-このブロックは内部的にはJSONで保持され、必要に応じて `video_prompt.instructions` に自然文の補助情報としても反映されます。
+このブロックは内部的にも送信用にもJSONで保持され、Sora送信用の最終出力では重複する自然文の `instructions` を追加しません。
 
 ---
 
@@ -221,12 +230,8 @@ tails:
   "video_prompt": {
     "prompt": "A serene zen garden at dawn with soft mist.",
     "video_style": {"scope": "full_movie", "description": "gentle cinematic look"},
-    "content_flags": {"narration": true, "bgm": true, "planned_cuts": 3},
-    "direction_constraints": {"environment_scope": "outdoor_only", "subject_tags": ["ruins", "wildlife"]},
-    "instructions": [
-      "Keep the entire video outdoors only.",
-      "Visually focus on these subjects: ruins, wildlife."
-    ]
+    "content_flags": {"narration_mode": "with_narration", "bgm_mode": "with_bgm", "planned_cuts": 3},
+    "direction_constraints": {"environment_scope": "outdoor_only", "subject_tags": ["ruins", "wildlife"], "still_frame_policy": "forbid"}
   }
 }
 ```
@@ -361,10 +366,10 @@ tails:
       "grade": "film emulation"
     },
     "content_flags": {
-      "narration": false,
-      "bgm": true,
-      "ambient_sound": true,
-      "dialogue": true
+      "narration_mode": "no_narration",
+      "bgm_mode": "with_bgm",
+      "ambient_sound_mode": "with_ambient_sound",
+      "dialogue_mode": "with_dialogue"
     },
     "direction_constraints": {
       "environment_scope": "outdoor_only",

--- a/app_image_prompt_creator_qt.py
+++ b/app_image_prompt_creator_qt.py
@@ -354,8 +354,63 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
                     push(cleaned)
         return tags
 
+    def _resolve_person_mode_from_defaults(self, defaults: dict) -> Optional[str]:
+        """旧 person_present/person_count と新 person_mode の両方から UI 用の人物モードを決める。"""
+        person_mode = defaults.get("person_mode")
+        if person_mode in {
+            "no_people",
+            "at_least_one_person",
+            "one_person",
+            "two_people",
+            "three_people",
+            "four_people",
+            "crowd",
+        }:
+            return person_mode
+
+        person_present = defaults.get("person_present")
+        person_count = defaults.get("person_count")
+        if person_count == 0:
+            return "no_people"
+        if person_count == "1+":
+            return "at_least_one_person"
+        if person_count == "many":
+            return "crowd"
+        if person_count == 1:
+            return "one_person"
+        if person_count == 2:
+            return "two_people"
+        if person_count == 3:
+            return "three_people"
+        if person_count == 4:
+            return "four_people"
+        if person_present is True:
+            return "at_least_one_person"
+        return None
+
+    def _resolve_focus_priority_from_defaults(self, defaults: dict) -> str:
+        """旧 subject_focus と新 focus_priority の両方から UI 用の主役優先度を決める。"""
+        focus_priority = str(defaults.get("focus_priority", "") or "").strip()
+        if focus_priority in ("people", "scene"):
+            return focus_priority
+        subject_focus = str(defaults.get("subject_focus", "") or "").strip()
+        if subject_focus == "people_primary":
+            return "people"
+        if subject_focus == "scene_primary":
+            return "scene"
+        return ""
+
     def _apply_content_flags_defaults(self, defaults: dict) -> None:
         """movie プリセットの content_flags 既定値を UI に反映する。"""
+        bgm_detail_keys = (
+            "bgm_genre",
+            "bgm_mood",
+            "bgm_tempo",
+            "bgm_vocal",
+            "bgm_sync",
+            "bgm_notes",
+        )
+        has_bgm_detail_defaults = any(defaults.get(key) not in (None, "") for key in bgm_detail_keys)
         widgets = [
             self.check_tail_flags_enabled,
             self.check_tail_flag_narration,
@@ -364,6 +419,13 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
             self.check_tail_flag_dialogue,
             self.check_tail_flag_dialogue_subtitle,
             self.check_tail_flag_telop,
+            self.group_bgm_options,
+            self.combo_tail_bgm_genre,
+            self.combo_tail_bgm_mood,
+            self.combo_tail_bgm_tempo,
+            self.combo_tail_bgm_vocal,
+            self.combo_tail_bgm_sync,
+            self.entry_tail_bgm_notes,
             self.combo_tail_person_count,
             self.combo_tail_cut_count,
             self.combo_tail_language,
@@ -371,25 +433,33 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
         blockers = [QtCore.QSignalBlocker(widget) for widget in widgets]
         try:
             self.check_tail_flags_enabled.setChecked(bool(defaults))
-            self.check_tail_flag_narration.setChecked(bool(defaults.get("narration", False)))
-            self.check_tail_flag_bgm.setChecked(bool(defaults.get("bgm", False)))
-            self.check_tail_flag_ambient.setChecked(bool(defaults.get("ambient_sound", False)))
-            self.check_tail_flag_dialogue.setChecked(bool(defaults.get("dialogue", False)))
-            self.check_tail_flag_dialogue_subtitle.setChecked(bool(defaults.get("on_screen_spoken_dialogue_subtitles")))
-            self.check_tail_flag_telop.setChecked(bool(defaults.get("on_screen_non_dialogue_text_overlays")))
-
-            person_present = defaults.get("person_present")
-            person_count = defaults.get("person_count")
-            if person_count == 0:
-                self._set_combo_to_data(self.combo_tail_person_count, 0)
-            elif person_present is False or person_count in (None, ""):
-                self._set_combo_to_data(self.combo_tail_person_count, None)
-            elif person_count in ("1+", "many", 1, 2, 3, 4):
-                self._set_combo_to_data(self.combo_tail_person_count, person_count)
-            elif person_present:
-                self._set_combo_to_data(self.combo_tail_person_count, "1+")
-            else:
-                self._set_combo_to_data(self.combo_tail_person_count, None)
+            self.check_tail_flag_narration.setChecked(
+                defaults.get("narration_mode") == "with_narration" or bool(defaults.get("narration", False))
+            )
+            self.check_tail_flag_bgm.setChecked(
+                defaults.get("bgm_mode") == "with_bgm" or bool(defaults.get("bgm", False) or has_bgm_detail_defaults)
+            )
+            self.check_tail_flag_ambient.setChecked(
+                defaults.get("ambient_sound_mode") == "with_ambient_sound" or bool(defaults.get("ambient_sound", False))
+            )
+            self.check_tail_flag_dialogue.setChecked(
+                defaults.get("dialogue_mode") == "with_dialogue" or bool(defaults.get("dialogue", False))
+            )
+            self.check_tail_flag_dialogue_subtitle.setChecked(
+                defaults.get("dialogue_subtitle_mode") == "with_dialogue_subtitles"
+                or bool(defaults.get("on_screen_spoken_dialogue_subtitles"))
+            )
+            self.check_tail_flag_telop.setChecked(
+                defaults.get("text_overlay_mode") == "with_text_overlays"
+                or bool(defaults.get("on_screen_non_dialogue_text_overlays"))
+            )
+            self._set_combo_to_data(self.combo_tail_bgm_genre, defaults.get("bgm_genre", ""))
+            self._set_combo_to_data(self.combo_tail_bgm_mood, defaults.get("bgm_mood", ""))
+            self._set_combo_to_data(self.combo_tail_bgm_tempo, defaults.get("bgm_tempo", ""))
+            self._set_combo_to_data(self.combo_tail_bgm_vocal, defaults.get("bgm_vocal", ""))
+            self._set_combo_to_data(self.combo_tail_bgm_sync, defaults.get("bgm_sync", ""))
+            self.entry_tail_bgm_notes.setText(str(defaults.get("bgm_notes", "") or ""))
+            self._set_combo_to_data(self.combo_tail_person_count, self._resolve_person_mode_from_defaults(defaults))
 
             planned_cuts = defaults.get("planned_cuts")
             if planned_cuts == "many" or isinstance(planned_cuts, int):
@@ -397,10 +467,11 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
             else:
                 self._set_combo_to_data(self.combo_tail_cut_count, None)
 
-            spoken_language = defaults.get("spoken_language", "")
-            self._set_combo_to_data(self.combo_tail_language, spoken_language if spoken_language in ("ja", "en") else "")
+            speech_language = defaults.get("speech_language", defaults.get("spoken_language", ""))
+            self._set_combo_to_data(self.combo_tail_language, speech_language if speech_language in ("ja", "en") else "")
         finally:
             del blockers
+            self._sync_bgm_detail_visibility()
 
     def _apply_direction_constraints_defaults(self, defaults: dict) -> None:
         """movie プリセットの演出制約既定値を UI に反映する。"""
@@ -444,18 +515,26 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
                     subject_tags_text = ""
             self.entry_direction_subject_tags.setText(subject_tags_text)
 
-            self.check_direction_allow_still_frames.setChecked(bool(defaults.get("allow_still_frames", True)))
+            still_frame_policy = str(defaults.get("still_frame_policy", "") or "").strip()
+            if still_frame_policy == "forbid":
+                self.check_direction_allow_still_frames.setChecked(False)
+            elif still_frame_policy == "allow":
+                self.check_direction_allow_still_frames.setChecked(True)
+            else:
+                self.check_direction_allow_still_frames.setChecked(bool(defaults.get("allow_still_frames", True)))
             self._set_combo_to_data(self.combo_direction_camera_motion, defaults.get("camera_motion", ""))
             self._set_combo_to_data(self.combo_direction_visual_energy, defaults.get("visual_energy", ""))
             self._set_combo_to_data(
                 self.combo_direction_cut_duration_policy,
                 defaults.get("cut_duration_policy", ""),
             )
-            self._set_combo_to_data(self.combo_direction_subject_focus, defaults.get("subject_focus", ""))
+            self._set_combo_to_data(self.combo_direction_subject_focus, self._resolve_focus_priority_from_defaults(defaults))
             self.entry_direction_freeform_constraints.setText(str(defaults.get("freeform_constraints", "")).strip())
-            self.check_direction_live_action_only.setChecked(bool(defaults.get("live_action_only", False)))
+            self.check_direction_live_action_only.setChecked(
+                defaults.get("render_style") == "live_action" or bool(defaults.get("live_action_only", False))
+            )
             self.check_direction_ultra_high_resolution_8k.setChecked(
-                bool(defaults.get("ultra_high_resolution_8k", False))
+                defaults.get("resolution_tier") == "8k" or bool(defaults.get("ultra_high_resolution_8k", False))
             )
         finally:
             del action_blockers
@@ -724,93 +803,91 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
         出力例:
         {
             "content_flags": {
-                "narration": true,
-                "person_present": true,
-                "person_count": 2,
-                "bgm": true,
-                "ambient_sound": true,
-                "dialogue": false,
-                "on_screen_spoken_dialogue_subtitles": "On-screen subtitles display the spoken dialogue in this video.",
-                "on_screen_non_dialogue_text_overlays": "There are on-screen non-dialogue text overlays such as commentary captions, labels, or sound-effect text rendered as part of the image.",
+                "narration_mode": "with_narration",
+                "bgm_mode": "with_bgm",
+                "bgm_genre": "cinematic",
+                "bgm_mood": "melancholic",
+                "bgm_tempo": "slow",
+                "bgm_vocal": "instrumental",
+                "bgm_sync": "beat_matched",
+                "bgm_notes": "Let the bass stay soft.",
+                "ambient_sound_mode": "with_ambient_sound",
+                "dialogue_mode": "no_dialogue",
+                "dialogue_subtitle_mode": "with_dialogue_subtitles",
+                "text_overlay_mode": "with_text_overlays",
+                "person_mode": "two_people",
                 "planned_cuts": 3,
-                "spoken_language": "ja"
+                "speech_language": "ja"
             }
         }
-        
-        narration / bgm / ambient_sound / dialogue は音声要素。
-        person_present は「映像内に人物が映っているかどうか」を表す視覚要素フラグ（true/false）。
-        person_count は人数指定で、0 / "1+"（1人以上）/ "many"（群衆・5人以上）または具体的な人数（1〜4の整数）を取る。
-          - 「(なし)」選択時: person_present=false, person_count は省略
-          - 「0人」選択時: person_present=false, person_count=0
-          - 「1人以上」選択時: person_present=true, person_count="1+"
-          - 「1人」〜「4人」選択時: person_present=true, person_count=N
-          - 「とても多い」選択時: person_present=true, person_count="many"
-        on_screen_spoken_dialogue_subtitles は「人物が話しているセリフそのものの字幕（セリフ字幕）が画面に表示されている」ことを、英語の説明文として明示します。
-        on_screen_non_dialogue_text_overlays は「ツッコミテロップや解説テキスト、効果音文字など、セリフとは異なる編集用テキストオーバーレイが存在する」ことを、英語の説明文として明示します。
+
+        false/true の二値より意味が強い mode 値を優先し、Sora 送信用 JSON を短く明確にする。
+        BGM が有効なときだけ、bgm_genre / bgm_mood / bgm_tempo / bgm_vocal / bgm_sync / bgm_notes が追加される。
+        person_mode は no_people / at_least_one_person / one_person / two_people / three_people / four_people / crowd を取る。
+        dialogue_subtitle_mode / text_overlay_mode は、該当要素がある時だけ出力する。
         planned_cuts は「作品全体をおおよそ何カットで構成するか」の目安（1〜15 または "many"）を表します。
-        spoken_language は「動画内で想定される主な話し言葉の言語」を表し、"ja" または "en" を取ります。
-        (Auto) 選択時や未指定時は planned_cuts / spoken_language フィールド自体を省略します。
+        speech_language は「動画内で想定される主な話し言葉の言語」を表し、"ja" または "en" を取ります。
+        (Auto) 選択時や未指定時は planned_cuts / speech_language フィールド自体を省略します。
         """
 
         # マスターチェックがOFFなら、フラグの値に関わらず JSON は付与しない
         if not getattr(self, "check_tail_flags_enabled", None) or not self.check_tail_flags_enabled.isChecked():
             return ""
 
+        narration_enabled = bool(self.check_tail_flag_narration.isChecked())
+        bgm_enabled = bool(self.check_tail_flag_bgm.isChecked())
+        ambient_enabled = bool(self.check_tail_flag_ambient.isChecked())
+        dialogue_enabled = bool(self.check_tail_flag_dialogue.isChecked())
         flags = {
-            "narration": bool(self.check_tail_flag_narration.isChecked()),
-            "bgm": bool(self.check_tail_flag_bgm.isChecked()),
-            "ambient_sound": bool(self.check_tail_flag_ambient.isChecked()),
-            "dialogue": bool(self.check_tail_flag_dialogue.isChecked()),
+            "narration_mode": "with_narration" if narration_enabled else "no_narration",
+            "bgm_mode": "with_bgm" if bgm_enabled else "no_bgm",
+            "ambient_sound_mode": "with_ambient_sound" if ambient_enabled else "no_ambient_sound",
+            "dialogue_mode": "with_dialogue" if dialogue_enabled else "no_dialogue",
         }
 
-        # 登場人物の人数を person_present / person_count として設定
-        # - "(なし)" → person_present: false のみ（未指定寄り）
-        # - "0人" → person_present: false, person_count: 0
-        # - "1人以上" → person_present: true, person_count: "1+"
-        # - "1人"〜"4人" → person_present: true, person_count: N
-        # - "とても多い" → person_present: true, person_count: "many"
+        def _read_combo_data(combo_name: str) -> str:
+            combo = getattr(self, combo_name, None)
+            if isinstance(combo, QtWidgets.QComboBox):
+                data = combo.currentData()
+                if isinstance(data, str) and data:
+                    return data
+            return ""
+
+        if bgm_enabled:
+            # BGM の詳細は flat な追加キーにしておくと、既存の content_flags 抽出ロジックを壊しにくい。
+            bgm_genre = _read_combo_data("combo_tail_bgm_genre")
+            if bgm_genre:
+                flags["bgm_genre"] = bgm_genre
+            bgm_mood = _read_combo_data("combo_tail_bgm_mood")
+            if bgm_mood:
+                flags["bgm_mood"] = bgm_mood
+            bgm_tempo = _read_combo_data("combo_tail_bgm_tempo")
+            if bgm_tempo:
+                flags["bgm_tempo"] = bgm_tempo
+            bgm_vocal = _read_combo_data("combo_tail_bgm_vocal")
+            if bgm_vocal:
+                flags["bgm_vocal"] = bgm_vocal
+            bgm_sync = _read_combo_data("combo_tail_bgm_sync")
+            if bgm_sync:
+                flags["bgm_sync"] = bgm_sync
+            bgm_notes_widget = getattr(self, "entry_tail_bgm_notes", None)
+            if isinstance(bgm_notes_widget, QtWidgets.QLineEdit):
+                bgm_notes = bgm_notes_widget.text().strip()
+                if bgm_notes:
+                    flags["bgm_notes"] = bgm_notes
+
+        # 人物数は person_present / person_count の二段構えではなく、意味の強い person_mode として表す。
         person_combo = getattr(self, "combo_tail_person_count", None)
         if isinstance(person_combo, QtWidgets.QComboBox):
-            person_data = person_combo.currentData()
-            if person_data is None:
-                # (なし) の場合: 人物なしだが、人数は未指定のままにする
-                flags["person_present"] = False
-            elif person_data == 0:
-                # 0人の場合: 明示的に人物ゼロを指定する
-                flags["person_present"] = False
-                flags["person_count"] = 0
-            elif person_data == "1+":
-                # 1人以上の場合: 人数を限定しない
-                flags["person_present"] = True
-                flags["person_count"] = "1+"
-            elif person_data == "many":
-                # 群衆など大人数のカット
-                flags["person_present"] = True
-                flags["person_count"] = "many"
-            elif isinstance(person_data, int) and person_data >= 1:
-                # 具体的な人数指定
-                flags["person_present"] = True
-                flags["person_count"] = person_data
-            else:
-                flags["person_present"] = False
-        else:
-            flags["person_present"] = False
+            person_mode = person_combo.currentData()
+            if isinstance(person_mode, str) and person_mode:
+                flags["person_mode"] = person_mode
 
-        # セリフそのものに対応した字幕（セリフ字幕）が画面に出ている場合は、
-        # true/false ではなく、動画モデルに直接伝わる英文の説明文を value として埋め込む。
         if self.check_tail_flag_dialogue_subtitle.isChecked():
-            flags["on_screen_spoken_dialogue_subtitles"] = (
-                "On-screen subtitles display the spoken dialogue in this video. "
-                "Subtitles are clearly visible and synchronized with the spoken voice."
-            )
+            flags["dialogue_subtitle_mode"] = "with_dialogue_subtitles"
 
-        # セリフとは異なる編集用テロップ/テキスト（ツッコミ・解説・効果音文字など）が映っている場合も、
-        # true/false ではなく、その存在を明示する英文の説明文を value として埋め込む。
         if self.check_tail_flag_telop.isChecked():
-            flags["on_screen_non_dialogue_text_overlays"] = (
-                "There are on-screen non-dialogue text overlays such as commentary captions, "
-                "labels, or sound-effect text rendered as part of the image."
-            )
+            flags["text_overlay_mode"] = "with_text_overlays"
         # 構成カット数 (1〜15 / "many") を planned_cuts として追加 (Auto の場合は省略)
         cut_combo = getattr(self, "combo_tail_cut_count", None)
         if isinstance(cut_combo, QtWidgets.QComboBox):
@@ -824,12 +901,12 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
                 flags["planned_cuts"] = data
             elif data == "many":
                 flags["planned_cuts"] = "many"
-        # 動画中の主な話し言葉の言語 ("ja" / "en") を spoken_language として追加 (Auto の場合は省略)
+        # 動画中の主な話し言葉の言語 ("ja" / "en") を speech_language として追加 (Auto の場合は省略)
         lang_combo = getattr(self, "combo_tail_language", None)
         if isinstance(lang_combo, QtWidgets.QComboBox):
             lang_code = lang_combo.currentData()
             if isinstance(lang_code, str) and lang_code in ("ja", "en"):
-                flags["spoken_language"] = lang_code
+                flags["speech_language"] = lang_code
         try:
             json_text = json.dumps({"content_flags": flags}, ensure_ascii=False)
         except Exception:
@@ -845,7 +922,7 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
             return ""
 
         constraints = {
-            "allow_still_frames": bool(self.check_direction_allow_still_frames.isChecked()),
+            "still_frame_policy": "allow" if self.check_direction_allow_still_frames.isChecked() else "forbid",
         }
 
         environment_scope = self.combo_direction_environment_scope.currentData()
@@ -868,19 +945,19 @@ class PromptGeneratorWindow(QtWidgets.QMainWindow, PromptUIMixin, PromptDataMixi
         if isinstance(cut_duration_policy, str) and cut_duration_policy:
             constraints["cut_duration_policy"] = cut_duration_policy
 
-        subject_focus = self.combo_direction_subject_focus.currentData()
-        if isinstance(subject_focus, str) and subject_focus:
-            constraints["subject_focus"] = subject_focus
+        focus_priority = self.combo_direction_subject_focus.currentData()
+        if isinstance(focus_priority, str) and focus_priority:
+            constraints["focus_priority"] = focus_priority
 
         freeform_constraints = self.entry_direction_freeform_constraints.text().strip()
         if freeform_constraints:
             constraints["freeform_constraints"] = freeform_constraints
 
         if self.check_direction_live_action_only.isChecked():
-            constraints["live_action_only"] = True
+            constraints["render_style"] = "live_action"
 
         if self.check_direction_ultra_high_resolution_8k.isChecked():
-            constraints["ultra_high_resolution_8k"] = True
+            constraints["resolution_tier"] = "8k"
 
         try:
             json_text = json.dumps({"direction_constraints": constraints}, ensure_ascii=False)

--- a/modules/config.py
+++ b/modules/config.py
@@ -48,6 +48,59 @@ STORYBOARD_AUTO_DEFAULT_DURATION = 12.0
 # content_flags.planned_cuts の手動候補レンジ
 CONTENT_FLAGS_PLANNED_CUTS_MIN = 1
 CONTENT_FLAGS_PLANNED_CUTS_MAX = 15
+CONTENT_FLAGS_PERSON_MODE_CHOICES = [
+    ("(なし)", None),
+    ("0人", "no_people"),
+    ("1人以上", "at_least_one_person"),
+    ("1人", "one_person"),
+    ("2人", "two_people"),
+    ("3人", "three_people"),
+    ("4人", "four_people"),
+    ("とても多い", "crowd"),
+]
+
+# content_flags.bgm の詳細オプション
+# UI 表示は日本語、内部値は軽量な英語トークンに揃える。
+BGM_GENRE_CHOICES = [
+    ("未指定", ""),
+    ("シネマティック", "cinematic"),
+    ("オーケストラ", "orchestral"),
+    ("ローファイ", "lofi"),
+    ("アンビエント", "ambient"),
+    ("エレクトロニック", "electronic"),
+    ("ロック", "rock"),
+    ("ジャズ", "jazz"),
+    ("ピアノ主体", "piano"),
+    ("和風", "japanese"),
+]
+BGM_MOOD_CHOICES = [
+    ("未指定", ""),
+    ("静か", "calm"),
+    ("切ない", "melancholic"),
+    ("高揚感", "uplifting"),
+    ("緊張感", "tense"),
+    ("神秘的", "mysterious"),
+    ("壮大", "epic"),
+    ("明るい", "bright"),
+]
+BGM_TEMPO_CHOICES = [
+    ("未指定", ""),
+    ("ゆっくり", "slow"),
+    ("ふつう", "medium"),
+    ("速い", "fast"),
+]
+BGM_VOCAL_CHOICES = [
+    ("未指定", ""),
+    ("インストゥルメンタル", "instrumental"),
+    ("ボーカルあり", "vocal"),
+    ("コーラス", "choir"),
+]
+BGM_SYNC_CHOICES = [
+    ("未指定", ""),
+    ("同期なし", "none"),
+    ("控えめに同期", "subtle"),
+    ("ビートに同期", "beat_matched"),
+]
 
 # direction_constraints の選択肢
 DIRECTION_ENVIRONMENT_SCOPE_CHOICES = [
@@ -94,8 +147,8 @@ DIRECTION_CUT_DURATION_POLICY_CHOICES = [
 ]
 DIRECTION_SUBJECT_FOCUS_CHOICES = [
     ("未指定", ""),
-    ("人物主体", "people_primary"),
-    ("情景主体", "scene_primary"),
+    ("人物主体", "people"),
+    ("情景主体", "scene"),
 ]
 
 # カメラワークの選択肢

--- a/modules/prompt_text_utils.py
+++ b/modules/prompt_text_utils.py
@@ -248,6 +248,84 @@ def _ensure_sentence(text: str) -> str:
     return normalized + "."
 
 
+_BGM_GENRE_SENTENCES = {
+    "cinematic": "Use a cinematic soundtrack.",
+    "orchestral": "Use an orchestral soundtrack.",
+    "lofi": "Use a lo-fi soundtrack.",
+    "ambient": "Use an ambient soundtrack.",
+    "electronic": "Use an electronic soundtrack.",
+    "rock": "Use a rock soundtrack.",
+    "jazz": "Use a jazz soundtrack.",
+    "piano": "Use a piano-led soundtrack.",
+    "japanese": "Use a Japanese-style soundtrack.",
+}
+_BGM_MOOD_SENTENCES = {
+    "calm": "Keep the music calm and restrained.",
+    "melancholic": "Keep the music melancholic.",
+    "uplifting": "Keep the music uplifting.",
+    "tense": "Keep the music tense.",
+    "mysterious": "Keep the music mysterious.",
+    "epic": "Keep the music epic and expansive.",
+    "bright": "Keep the music bright and cheerful.",
+}
+_BGM_TEMPO_SENTENCES = {
+    "slow": "Use a slow tempo.",
+    "medium": "Use a medium tempo.",
+    "fast": "Use a fast tempo.",
+}
+_BGM_VOCAL_SENTENCES = {
+    "instrumental": "Keep the track instrumental.",
+    "vocal": "Include vocals.",
+    "choir": "Include choir-like vocals.",
+}
+_BGM_SYNC_SENTENCES = {
+    "none": "Do not tightly sync the music to the edit rhythm.",
+    "subtle": "Keep the music subtly aligned with the edit rhythm.",
+    "beat_matched": "Synchronize the music with the edit rhythm.",
+}
+_CONTENT_MODE_SENTENCES = {
+    "narration_mode": {
+        "with_narration": "Use narration.",
+        "no_narration": "Do not use narration.",
+    },
+    "bgm_mode": {
+        "with_bgm": "Use background music.",
+        "no_bgm": "Do not use background music.",
+    },
+    "ambient_sound_mode": {
+        "with_ambient_sound": "Include ambient environmental sound.",
+        "no_ambient_sound": "Do not use ambient environmental sound.",
+    },
+    "dialogue_mode": {
+        "with_dialogue": "Include spoken dialogue.",
+        "no_dialogue": "Do not use spoken dialogue.",
+    },
+}
+_PERSON_MODE_SENTENCES = {
+    "no_people": "No people appear on screen.",
+    "at_least_one_person": "At least one person appears on screen.",
+    "one_person": "Show exactly one person on screen.",
+    "two_people": "Show exactly two people on screen.",
+    "three_people": "Show exactly three people on screen.",
+    "four_people": "Show exactly four people on screen.",
+    "crowd": "Many people appear on screen.",
+}
+_STILL_FRAME_POLICY_SENTENCES = {
+    "forbid": "Avoid still or frozen-looking frames.",
+    "allow": "",
+}
+_FOCUS_PRIORITY_SENTENCES = {
+    "people": "Keep people as the primary visual focus of the composition whenever they appear on screen.",
+    "scene": "Even if people appear on screen, keep the environment, scenery, and overall scene as the primary visual focus rather than individual people.",
+}
+_RENDER_STYLE_SENTENCES = {
+    "live_action": "Render the entire video as fully live-action footage with no animated or illustrative look.",
+}
+_RESOLUTION_TIER_SENTENCES = {
+    "8k": "Render the entire video in ultra high resolution 8K quality.",
+}
+
+
 def strip_compiled_movie_requirements(prompt_text: str) -> str:
     """prompt 末尾に追記した Video requirements ブロックを取り除く。"""
     text = (prompt_text or "").strip()
@@ -264,41 +342,76 @@ def _compile_content_flags_to_sentences(content_flags: dict | None) -> List[str]
         return []
 
     sentences: List[str] = []
-    flag_phrases = {
+    for key, mapping in _CONTENT_MODE_SENTENCES.items():
+        value = content_flags.get(key)
+        if isinstance(value, str) and value in mapping and mapping[value]:
+            sentences.append(_ensure_sentence(mapping[value]))
+
+    # 旧 schema 互換
+    legacy_flag_phrases = {
         "narration": ("Use narration", "Do not use narration"),
         "bgm": ("Use background music", "Do not use background music"),
         "ambient_sound": ("Include ambient environmental sound", "Do not use ambient environmental sound"),
         "dialogue": ("Include spoken dialogue", "Do not use spoken dialogue"),
     }
-    for key, (positive, negative) in flag_phrases.items():
+    for key, (positive, negative) in legacy_flag_phrases.items():
+        if f"{key}_mode" in content_flags:
+            continue
         value = content_flags.get(key)
         if value is True:
             sentences.append(_ensure_sentence(positive))
         elif value is False:
             sentences.append(_ensure_sentence(negative))
 
-    person_present = content_flags.get("person_present")
-    person_count = content_flags.get("person_count")
-    if person_present is False:
-        sentences.append("No people appear on screen.")
-    elif person_present is True:
-        if person_count == "1+":
-            sentences.append("At least one person appears on screen.")
-        elif person_count == "many":
-            sentences.append("Many people appear on screen.")
-        elif isinstance(person_count, int) and person_count >= 1:
-            sentences.append(_ensure_sentence(f"Show {person_count} people on screen"))
-        else:
-            sentences.append("People appear on screen.")
+    bgm_mode = content_flags.get("bgm_mode")
+    bgm_enabled = bgm_mode == "with_bgm" or (bgm_mode is None and content_flags.get("bgm") is True)
+    if bgm_enabled:
+        # BGM の詳細は flat な追加キーで持たせ、既存の content_flags 互換性を保つ。
+        for key, mapping in (
+            ("bgm_genre", _BGM_GENRE_SENTENCES),
+            ("bgm_mood", _BGM_MOOD_SENTENCES),
+            ("bgm_tempo", _BGM_TEMPO_SENTENCES),
+            ("bgm_vocal", _BGM_VOCAL_SENTENCES),
+            ("bgm_sync", _BGM_SYNC_SENTENCES),
+        ):
+            value = content_flags.get(key)
+            if isinstance(value, str) and value in mapping:
+                sentences.append(_ensure_sentence(mapping[value]))
 
-    if content_flags.get("on_screen_spoken_dialogue_subtitles"):
+        bgm_notes = content_flags.get("bgm_notes")
+        if isinstance(bgm_notes, str) and bgm_notes.strip():
+            sentences.append(_ensure_sentence(bgm_notes))
+
+    person_mode = content_flags.get("person_mode")
+    if isinstance(person_mode, str) and person_mode in _PERSON_MODE_SENTENCES:
+        sentences.append(_PERSON_MODE_SENTENCES[person_mode])
+    else:
+        person_present = content_flags.get("person_present")
+        person_count = content_flags.get("person_count")
+        if person_present is False:
+            sentences.append("No people appear on screen.")
+        elif person_present is True:
+            if person_count == "1+":
+                sentences.append("At least one person appears on screen.")
+            elif person_count == "many":
+                sentences.append("Many people appear on screen.")
+            elif isinstance(person_count, int) and person_count >= 1:
+                sentences.append(_ensure_sentence(f"Show {person_count} people on screen"))
+            else:
+                sentences.append("People appear on screen.")
+
+    if content_flags.get("dialogue_subtitle_mode") == "with_dialogue_subtitles" or content_flags.get(
+        "on_screen_spoken_dialogue_subtitles"
+    ):
         sentences.append("Display on-screen subtitles for the spoken dialogue.")
-    if content_flags.get("on_screen_non_dialogue_text_overlays"):
+    if content_flags.get("text_overlay_mode") == "with_text_overlays" or content_flags.get(
+        "on_screen_non_dialogue_text_overlays"
+    ):
         sentences.append("Display non-dialogue text overlays on screen.")
 
-    spoken_language = content_flags.get("spoken_language")
-    if isinstance(spoken_language, str) and spoken_language in ("ja", "en"):
-        language_label = "Japanese" if spoken_language == "ja" else "English"
+    speech_language = content_flags.get("speech_language", content_flags.get("spoken_language"))
+    if isinstance(speech_language, str) and speech_language in ("ja", "en"):
+        language_label = "Japanese" if speech_language == "ja" else "English"
         sentences.append(_ensure_sentence(f"If speech is present, use {language_label}"))
 
     return sentences
@@ -349,9 +462,15 @@ def _compile_direction_constraints_to_sentences(direction_constraints: dict | No
             readable_tags = [readable_map.get(tag, tag) for tag in tags]
             sentences.append(_ensure_sentence(f"Visually focus on these subjects: {', '.join(readable_tags)}"))
 
-    allow_still_frames = direction_constraints.get("allow_still_frames")
-    if allow_still_frames is False:
-        sentences.append("Avoid still or frozen-looking frames.")
+    still_frame_policy = direction_constraints.get("still_frame_policy")
+    if isinstance(still_frame_policy, str) and still_frame_policy in _STILL_FRAME_POLICY_SENTENCES:
+        sentence = _STILL_FRAME_POLICY_SENTENCES[still_frame_policy]
+        if sentence:
+            sentences.append(sentence)
+    else:
+        allow_still_frames = direction_constraints.get("allow_still_frames")
+        if allow_still_frames is False:
+            sentences.append("Avoid still or frozen-looking frames.")
 
     camera_motion = direction_constraints.get("camera_motion")
     if camera_motion == "mostly_static":
@@ -377,22 +496,32 @@ def _compile_direction_constraints_to_sentences(direction_constraints: dict | No
     elif cut_duration_policy == "variable":
         sentences.append("Cut durations do not need to be evenly distributed.")
 
-    subject_focus = direction_constraints.get("subject_focus")
-    if subject_focus == "people_primary":
-        sentences.append("Keep people as the primary visual focus of the composition whenever they appear on screen.")
-    elif subject_focus == "scene_primary":
-        sentences.append(
-            "Even if people appear on screen, keep the environment, scenery, and overall scene as the primary visual focus rather than individual people."
-        )
+    focus_priority = direction_constraints.get("focus_priority")
+    if isinstance(focus_priority, str) and focus_priority in _FOCUS_PRIORITY_SENTENCES:
+        sentences.append(_FOCUS_PRIORITY_SENTENCES[focus_priority])
+    else:
+        subject_focus = direction_constraints.get("subject_focus")
+        if subject_focus == "people_primary":
+            sentences.append("Keep people as the primary visual focus of the composition whenever they appear on screen.")
+        elif subject_focus == "scene_primary":
+            sentences.append(
+                "Even if people appear on screen, keep the environment, scenery, and overall scene as the primary visual focus rather than individual people."
+            )
 
     freeform_constraints = direction_constraints.get("freeform_constraints")
     if isinstance(freeform_constraints, str) and freeform_constraints.strip():
         sentences.append(_ensure_sentence(freeform_constraints))
 
-    if direction_constraints.get("live_action_only") is True:
+    render_style = direction_constraints.get("render_style")
+    if isinstance(render_style, str) and render_style in _RENDER_STYLE_SENTENCES:
+        sentences.append(_RENDER_STYLE_SENTENCES[render_style])
+    elif direction_constraints.get("live_action_only") is True:
         sentences.append("Render the entire video as fully live-action footage with no animated or illustrative look.")
 
-    if direction_constraints.get("ultra_high_resolution_8k") is True:
+    resolution_tier = direction_constraints.get("resolution_tier")
+    if isinstance(resolution_tier, str) and resolution_tier in _RESOLUTION_TIER_SENTENCES:
+        sentences.append(_RESOLUTION_TIER_SENTENCES[resolution_tier])
+    elif direction_constraints.get("ultra_high_resolution_8k") is True:
         sentences.append("Render the entire video in ultra high resolution 8K quality.")
 
     return sentences
@@ -528,12 +657,7 @@ def compose_movie_prompt(
     if prompt_text or "prompt" in base_payload["video_prompt"]:
         base_payload["video_prompt"]["prompt"] = prompt_text
 
-    compiled_instructions = compile_movie_instructions(
-        base_payload["video_prompt"].get("content_flags"),
-        base_payload["video_prompt"].get("direction_constraints"),
-    )
-    if compiled_instructions:
-        base_payload["video_prompt"]["instructions"] = compiled_instructions
+    # Sora 送信用の最終JSONでは、構造化メタデータと自然文 instructions の二重保持を避ける。
 
     # Sora Web/iOS では --ar などのMJオプションは不要なので options_tail は無視する
 

--- a/modules/prompt_ui_mixins.py
+++ b/modules/prompt_ui_mixins.py
@@ -39,6 +39,14 @@ class PromptUIMixin:
         self.group_midjourney_options.setVisible(not is_movie)
         self.check_attached_image_world_prefix.setVisible(is_movie)
 
+    def _sync_bgm_detail_visibility(self) -> None:
+        """BGM の有無に合わせて、詳細入力を有効化/無効化する。"""
+
+        group = getattr(self, "group_bgm_options", None)
+        checkbox = getattr(self, "check_tail_flag_bgm", None)
+        if isinstance(group, QtWidgets.QGroupBox):
+            group.setEnabled(bool(checkbox and checkbox.isChecked()))
+
     def _build_ui(self):
         central = QtWidgets.QWidget()
         self.setCentralWidget(central)
@@ -411,21 +419,68 @@ class PromptUIMixin:
             flags_row.addWidget(chk)
         tail2_layout.addLayout(flags_row)
 
+        # BGM を ON にした時だけ、曲調・雰囲気・同期方法の詳細を指定できる。
+        self.group_bgm_options = QtWidgets.QGroupBox("BGM詳細")
+        bgm_form = QtWidgets.QFormLayout(self.group_bgm_options)
+        bgm_form.setLabelAlignment(QtCore.Qt.AlignLeft)
+        bgm_form.setFormAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
+        bgm_form.setHorizontalSpacing(10)
+        bgm_form.setVerticalSpacing(8)
+
+        self.combo_tail_bgm_genre = QtWidgets.QComboBox()
+        for label, value in config.BGM_GENRE_CHOICES:
+            self.combo_tail_bgm_genre.addItem(label, userData=value)
+        self.combo_tail_bgm_genre.setToolTip("BGM の音楽ジャンルを日本語表記のプルダウンから選びます。")
+        self.combo_tail_bgm_genre.currentIndexChanged.connect(self.auto_update)
+        bgm_form.addRow("ジャンル:", self.combo_tail_bgm_genre)
+
+        self.combo_tail_bgm_mood = QtWidgets.QComboBox()
+        for label, value in config.BGM_MOOD_CHOICES:
+            self.combo_tail_bgm_mood.addItem(label, userData=value)
+        self.combo_tail_bgm_mood.setToolTip("BGM の雰囲気を日本語表記のプルダウンから選びます。")
+        self.combo_tail_bgm_mood.currentIndexChanged.connect(self.auto_update)
+        bgm_form.addRow("雰囲気:", self.combo_tail_bgm_mood)
+
+        self.combo_tail_bgm_tempo = QtWidgets.QComboBox()
+        for label, value in config.BGM_TEMPO_CHOICES:
+            self.combo_tail_bgm_tempo.addItem(label, userData=value)
+        self.combo_tail_bgm_tempo.setToolTip("BGM のテンポ感を日本語表記のプルダウンから選びます。")
+        self.combo_tail_bgm_tempo.currentIndexChanged.connect(self.auto_update)
+        bgm_form.addRow("テンポ:", self.combo_tail_bgm_tempo)
+
+        self.combo_tail_bgm_vocal = QtWidgets.QComboBox()
+        for label, value in config.BGM_VOCAL_CHOICES:
+            self.combo_tail_bgm_vocal.addItem(label, userData=value)
+        self.combo_tail_bgm_vocal.setToolTip("歌声の有無やコーラス感を日本語表記のプルダウンから選びます。")
+        self.combo_tail_bgm_vocal.currentIndexChanged.connect(self.auto_update)
+        bgm_form.addRow("ボーカル:", self.combo_tail_bgm_vocal)
+
+        self.combo_tail_bgm_sync = QtWidgets.QComboBox()
+        for label, value in config.BGM_SYNC_CHOICES:
+            self.combo_tail_bgm_sync.addItem(label, userData=value)
+        self.combo_tail_bgm_sync.setToolTip("映像編集やカットのリズムとの同期方針を日本語表記のプルダウンから選びます。")
+        self.combo_tail_bgm_sync.currentIndexChanged.connect(self.auto_update)
+        bgm_form.addRow("同期:", self.combo_tail_bgm_sync)
+
+        self.entry_tail_bgm_notes = QtWidgets.QLineEdit()
+        self.entry_tail_bgm_notes.setPlaceholderText("例: 低音を控えめに、後半だけ少し盛り上げる")
+        self.entry_tail_bgm_notes.setToolTip("プルダウンに収まらないBGM指示を自由記述で補足します。")
+        self.entry_tail_bgm_notes.textChanged.connect(self.auto_update)
+        bgm_form.addRow("追加メモ:", self.entry_tail_bgm_notes)
+        tail2_layout.addWidget(self.group_bgm_options)
+        self.check_tail_flag_bgm.stateChanged.connect(self._sync_bgm_detail_visibility)
+
         # 登場人物（動画用）
-        # person_present/person_count を末尾2(content_flags)へ反映するための入力UI。
+        # 人物数を意味の強い person_mode として末尾2(content_flags)へ反映するための入力UI。
         person_row = QtWidgets.QHBoxLayout()
         person_row.addWidget(QtWidgets.QLabel("登場人物(動画用):"))
         self.combo_tail_person_count = QtWidgets.QComboBox()
-        self.combo_tail_person_count.addItem("(なし)", userData=None)
-        self.combo_tail_person_count.addItem("0人", userData=0)
-        self.combo_tail_person_count.addItem("1人以上", userData="1+")
-        for i in range(1, 5):
-            self.combo_tail_person_count.addItem(f"{i}人", userData=i)
-        self.combo_tail_person_count.addItem("とても多い", userData="many")
+        for label, value in config.CONTENT_FLAGS_PERSON_MODE_CHOICES:
+            self.combo_tail_person_count.addItem(label, userData=value)
         self.combo_tail_person_count.setToolTip(
-            "映像内に人物が映っているかどうかと、おおよその人数を指定します。"
-            "「0人」は person_present=false, person_count=0 として明示的に人物ゼロを出力します。"
-            "「とても多い」は person_count=\"many\"（群衆・大人数）として JSON に反映されます。"
+            "映像内の人物数を、否定の真偽値ではなく意味の強いモード値として出力します。"
+            "「0人」は person_mode=\"no_people\"、"
+            "「とても多い」は person_mode=\"crowd\" として JSON に反映されます。"
         )
         self.combo_tail_person_count.currentIndexChanged.connect(self.auto_update)
         person_row.addWidget(self.combo_tail_person_count)
@@ -466,6 +521,7 @@ class PromptUIMixin:
         tail2_layout.addLayout(lang_row)
 
         tail_form.addRow(tail2_group)
+        self._sync_bgm_detail_visibility()
 
         direction_group = QtWidgets.QGroupBox("演出制約 (direction_constraints)")
         direction_layout = QtWidgets.QVBoxLayout(direction_group)
@@ -525,7 +581,7 @@ class PromptUIMixin:
         self.check_direction_allow_still_frames = QtWidgets.QCheckBox("静止画カットを許可")
         self.check_direction_allow_still_frames.setChecked(True)
         self.check_direction_allow_still_frames.setToolTip(
-            "OFF にすると allow_still_frames=false として、静止画のような停止カットを禁止します。"
+            "OFF にすると still_frame_policy=\"forbid\" として、静止画のような停止カットを禁止します。"
         )
         self.check_direction_allow_still_frames.stateChanged.connect(self.auto_update)
         direction_row_2.addWidget(self.check_direction_allow_still_frames)

--- a/modules/storyboard.py
+++ b/modules/storyboard.py
@@ -14,7 +14,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import config
 from .prompt_data import SoraCharacter, StoryboardCut, load_sora_characters
-from .prompt_text_utils import compile_movie_instructions, strip_compiled_movie_requirements
+from .prompt_text_utils import strip_compiled_movie_requirements
 
 
 def _adjust_last_cut_duration(cuts: List[StoryboardCut], total_duration_sec: float) -> List[StoryboardCut]:
@@ -357,9 +357,6 @@ def build_storyboard_json(
     continuity_enhanced: bool = False,
 ) -> str:
     """ストーリーボードのカットリストをSora向け `video_prompt` 形式でJSON化する。
-
-    `compose_movie_prompt()` と同じく、content_flags / direction_constraints がある場合は
-    動画モデルが解釈しやすい自然文の `instructions` も併せて出力する。
     """
     cuts_data = []
     for cut in cuts:
@@ -391,10 +388,6 @@ def build_storyboard_json(
         payload["video_prompt"]["content_flags"] = content_flags
     if direction_constraints:
         payload["video_prompt"]["direction_constraints"] = direction_constraints
-
-    compiled_instructions = compile_movie_instructions(content_flags, direction_constraints)
-    if compiled_instructions:
-        payload["video_prompt"]["instructions"] = compiled_instructions
 
     return json.dumps(payload, ensure_ascii=False, indent=2)
 

--- a/tests/test_generate_text_qt.py
+++ b/tests/test_generate_text_qt.py
@@ -529,8 +529,8 @@ def test_extract_metadata_from_prompt_video_prompt_without_body_falls_back_to_fu
     assert "video_prompt" in prompt_text
 
 
-def test_build_storyboard_json_includes_compiled_instructions():
-    """ストーリーボードJSONでも content_flags / direction_constraints から instructions を組み立てること。"""
+def test_build_storyboard_json_keeps_structured_movie_metadata():
+    """ストーリーボードJSONでは instructions を持たず、構造化メタデータをそのまま保持すること。"""
 
     from modules.prompt_data import StoryboardCut
     from modules.storyboard import build_storyboard_json
@@ -542,42 +542,110 @@ def test_build_storyboard_json_includes_compiled_instructions():
         ],
         total_duration_sec=10.0,
         template_id="none",
-        content_flags={"dialogue": False, "person_present": False},
+        content_flags={"dialogue_mode": "no_dialogue", "person_mode": "no_people"},
         direction_constraints={"environment_scope": "outdoor_only", "camera_motion": "continuous"},
     )
 
     payload = qt_app.json.loads(result)
     assert payload["video_prompt"]["storyboard"]["total_duration_sec"] == 10.0
-    assert "Do not use spoken dialogue." in payload["video_prompt"]["instructions"]
-    assert "No people appear on screen." in payload["video_prompt"]["instructions"]
-    assert "Keep the entire video outdoors only." in payload["video_prompt"]["instructions"]
-    assert "Keep the camera moving continuously." in payload["video_prompt"]["instructions"]
+    assert payload["video_prompt"]["content_flags"]["dialogue_mode"] == "no_dialogue"
+    assert payload["video_prompt"]["content_flags"]["person_mode"] == "no_people"
+    assert payload["video_prompt"]["direction_constraints"]["environment_scope"] == "outdoor_only"
+    assert "instructions" not in payload["video_prompt"]
 
 
 def test_compose_movie_prompt_keeps_direction_constraints():
-    """動画JSON統合時に prompt を汚さず、自然文要件は instructions に分離すること。"""
+    """動画JSON統合時に prompt を汚さず、送信用は構造化メタデータだけを保持すること。"""
 
     from modules.prompt_text_utils import compose_movie_prompt
 
     result = compose_movie_prompt(
         core_json='{"prompt":"A vast interior atrium."}',
         movie_tail='{"video_style":{"scope":"full_movie","format":"8K"}}',
-        flags_tail='{"content_flags":{"bgm":true,"dialogue":false,"person_present":false}}',
+        flags_tail='{"content_flags":{"bgm_mode":"with_bgm","dialogue_mode":"no_dialogue","person_mode":"no_people"}}',
         direction_tail='{"direction_constraints":{"environment_scope":"outdoor_only","subject_tags":["ruins","wildlife"],"camera_motion":"continuous"}}',
         options_tail="",
     )
 
     payload = qt_app.json.loads(result)
     assert payload["video_prompt"]["video_style"]["format"] == "8K"
-    assert payload["video_prompt"]["content_flags"]["bgm"] is True
+    assert payload["video_prompt"]["content_flags"]["bgm_mode"] == "with_bgm"
+    assert payload["video_prompt"]["content_flags"]["dialogue_mode"] == "no_dialogue"
+    assert payload["video_prompt"]["content_flags"]["person_mode"] == "no_people"
     assert payload["video_prompt"]["direction_constraints"]["environment_scope"] == "outdoor_only"
     assert payload["video_prompt"]["direction_constraints"]["subject_tags"] == ["ruins", "wildlife"]
     assert payload["video_prompt"]["direction_constraints"]["camera_motion"] == "continuous"
     assert payload["video_prompt"]["prompt"] == "A vast interior atrium."
-    assert "Do not use spoken dialogue." in payload["video_prompt"]["instructions"]
-    assert "No people appear on screen." in payload["video_prompt"]["instructions"]
-    assert "Keep the entire video outdoors only." in payload["video_prompt"]["instructions"]
-    assert "Visually focus on these subjects: ruins, wildlife." in payload["video_prompt"]["instructions"]
+    assert "instructions" not in payload["video_prompt"]
+
+
+def test_compile_movie_instructions_include_bgm_details():
+    """BGM 詳細が自然文の補助指示へ展開されること。"""
+
+    from modules.prompt_text_utils import compile_movie_instructions
+
+    instructions = compile_movie_instructions(
+        {
+            "bgm_mode": "with_bgm",
+            "bgm_genre": "cinematic",
+            "bgm_mood": "melancholic",
+            "bgm_tempo": "slow",
+            "bgm_vocal": "instrumental",
+            "bgm_sync": "beat_matched",
+            "bgm_notes": "Let the bass stay soft.",
+        },
+        None,
+    )
+
+    assert "Use background music." in instructions
+    assert "Use a cinematic soundtrack." in instructions
+    assert "Keep the music melancholic." in instructions
+    assert "Use a slow tempo." in instructions
+    assert "Keep the track instrumental." in instructions
+    assert "Synchronize the music with the edit rhythm." in instructions
+    assert "Let the bass stay soft." in instructions
+
+
+def test_bgm_dropdown_labels_are_japanese(prompt_generator):
+    """BGM のプルダウンは日本語ラベルで表示されること。"""
+
+    genre_combo = prompt_generator.combo_tail_bgm_genre
+    mood_combo = prompt_generator.combo_tail_bgm_mood
+
+    assert genre_combo.itemText(0) == "未指定"
+    assert genre_combo.itemText(genre_combo.findData("cinematic")) == "シネマティック"
+    assert mood_combo.itemText(mood_combo.findData("melancholic")) == "切ない"
+
+
+def test_make_tail_flags_json_includes_bgm_details(prompt_generator):
+    """BGM を有効にすると詳細設定が content_flags に含まれること。"""
+
+    prompt_generator.check_tail_flags_enabled.setChecked(True)
+    prompt_generator.check_tail_flag_bgm.setChecked(True)
+    prompt_generator.combo_tail_bgm_genre.setCurrentIndex(prompt_generator.combo_tail_bgm_genre.findData("cinematic"))
+    prompt_generator.combo_tail_bgm_mood.setCurrentIndex(prompt_generator.combo_tail_bgm_mood.findData("melancholic"))
+    prompt_generator.combo_tail_bgm_tempo.setCurrentIndex(prompt_generator.combo_tail_bgm_tempo.findData("slow"))
+    prompt_generator.combo_tail_bgm_vocal.setCurrentIndex(
+        prompt_generator.combo_tail_bgm_vocal.findData("instrumental")
+    )
+    prompt_generator.combo_tail_bgm_sync.setCurrentIndex(
+        prompt_generator.combo_tail_bgm_sync.findData("beat_matched")
+    )
+    prompt_generator.entry_tail_bgm_notes.setText("後半だけ少し盛り上げる。")
+
+    payload = qt_app.json.loads(prompt_generator._make_tail_flags_json().strip())
+    flags = payload["content_flags"]
+
+    assert flags["bgm_mode"] == "with_bgm"
+    assert flags["narration_mode"] == "no_narration"
+    assert flags["ambient_sound_mode"] == "no_ambient_sound"
+    assert flags["dialogue_mode"] == "no_dialogue"
+    assert flags["bgm_genre"] == "cinematic"
+    assert flags["bgm_mood"] == "melancholic"
+    assert flags["bgm_tempo"] == "slow"
+    assert flags["bgm_vocal"] == "instrumental"
+    assert flags["bgm_sync"] == "beat_matched"
+    assert flags["bgm_notes"] == "後半だけ少し盛り上げる。"
 
 
 def test_prepend_attached_image_world_description_updates_video_style_description():
@@ -641,16 +709,16 @@ def test_make_direction_constraints_json_from_ui(prompt_generator):
 
     assert payload == {
         "direction_constraints": {
-            "allow_still_frames": False,
+            "still_frame_policy": "forbid",
             "environment_scope": "underwater",
             "subject_tags": ["water_features", "celestial_bodies", "coral reef"],
             "camera_motion": "continuous",
             "visual_energy": "vivid",
             "cut_duration_policy": "variable",
-            "subject_focus": "scene_primary",
+            "focus_priority": "scene",
             "freeform_constraints": "Avoid modern urban elements.",
-            "live_action_only": True,
-            "ultra_high_resolution_8k": True,
+            "render_style": "live_action",
+            "resolution_tier": "8k",
         }
     }
     assert prompt_generator.label_direction_common_subjects.text() in ("水辺・水域 / 天体", "天体 / 水辺・水域")
@@ -664,8 +732,8 @@ def test_movie_direction_constraints_compile_new_quality_flags():
     instructions = compile_movie_instructions(
         None,
         {
-            "live_action_only": True,
-            "ultra_high_resolution_8k": True,
+            "render_style": "live_action",
+            "resolution_tier": "8k",
         },
     )
 
@@ -679,8 +747,8 @@ def test_movie_direction_constraints_compile_subject_focus():
     from modules.prompt_text_utils import compile_movie_instructions
 
     instructions = compile_movie_instructions(
-        {"person_present": True, "person_count": "1+"},
-        {"subject_focus": "scene_primary"},
+        {"person_mode": "at_least_one_person"},
+        {"focus_priority": "scene"},
     )
 
     assert "At least one person appears on screen." in instructions
@@ -691,15 +759,14 @@ def test_movie_direction_constraints_compile_subject_focus():
 
 
 def test_make_tail_flags_json_supports_explicit_zero_people(prompt_generator):
-    """0人選択時は未指定ではなく person_count=0 を明示出力すること。"""
+    """0人選択時は person_mode=no_people を明示出力すること。"""
 
     prompt_generator.check_tail_flags_enabled.setChecked(True)
     prompt_generator.combo_tail_person_count.setCurrentText("0人")
 
     payload = qt_app.json.loads(prompt_generator._make_tail_flags_json().strip())
 
-    assert payload["content_flags"]["person_present"] is False
-    assert payload["content_flags"]["person_count"] == 0
+    assert payload["content_flags"]["person_mode"] == "no_people"
 
 
 def test_movie_tail_media_type_hides_midjourney_options(prompt_generator):


### PR DESCRIPTION
## 概要
- 動画メタデータを `*_mode` / `*_policy` の明示的な値へ寄せ、Sora 送信用 JSON をよりコンパクトで意味が伝わりやすい形に整理しました。
- 最終送信用の `video_prompt.instructions` は廃止し、構造化JSONをそのまま出力する方針に変更しました。
- 入力側は旧キーも読めるようにしつつ、出力側は新スキーマへ統一しています。

## 移行メモ
- `dialogue: false` -> `dialogue_mode: no_dialogue`
- `person_present/person_count` -> `person_mode`
- `allow_still_frames: false` -> `still_frame_policy: forbid`
- `subject_focus` -> `focus_priority`
- `live_action_only` -> `render_style: live_action`
- `ultra_high_resolution_8k` -> `resolution_tier: 8k`

## テスト
- `python -m pytest app_image_prompt_creator/tests/test_generate_text_qt.py -q`
- 結果: `35 passed`

## Docs
- `README.md` を新スキーマと instruction-free な送信用JSONに合わせて更新しました。

Docs: updated